### PR TITLE
Add access-nri-intake

### DIFF
--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -20,6 +20,7 @@ dependencies:
 - dask
 - iris
 - intake
+- access-nri-intake
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - numpy>=1.21 # Mule dependency
 - pandas


### PR DESCRIPTION
This PR adds `access-nri-intake` to the existing `access-med-0.1` environment (I think)