### PR TITLE
Add dask-labextension

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -96,7 +96,7 @@ function inner() {
     conda activate "${CONDA_INSTALLATION_PATH}/envs/${FULLENV}"
     set -u
 
-    #jupyter lab build
+    jupyter lab build
 
     conda clean -a -f -y
 

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -25,6 +25,7 @@ dependencies:
 - intake
 - access-nri-intake
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
+- nodejs
 - numpy>=1.21 # Mule dependency
 - pandas
 - scipy

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -18,6 +18,7 @@ dependencies:
 - jinja2
 - ilamb
 - dask
+- dask-labextension
 - hvplot
 - datashader
 - iris


### PR DESCRIPTION
The dask dashboard is kind of essential for using dask. I'm not sure whether additional set-up is required to get this running of the ARE. I guess we'll find out...