### PR TITLE
Update access-nri-intake

### DIFF
--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - datashader
 - iris
 - intake
-- access-nri-intake
+- access-nri-intake==0.0.7 # Keep pinned to latest version while in development
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - nodejs
 - numpy>=1.21 # Mule dependency


### PR DESCRIPTION
This PR updates access-nri-intake to the latest version by pinning it to that version. We discussed offline, and it was decided that this is how we should update packages that we are currently developing.