### PR TITLE
Fix jupyterlab issue

### DIFF
--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -14,8 +14,7 @@ dependencies:
 - autopep8
 - pyyaml
 - cdo>=1.9.5 # pinned for solver stability
-# pinning matplotlib to 3.5.3 temporarily until plotnine issue is fixed https://github.com/has2k1/plotnine/issues/620
-- matplotlib==3.5.3  #
+- matplotlib
 - jinja2
 - ilamb
 - dask
@@ -27,8 +26,8 @@ dependencies:
 - iris-esmf-regrid
 - intake
 - access-nri-intake==0.0.8 # Keep pinned to latest version while in development
-# - intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
-# - ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
+- intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
+- ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
 - pydantic<2.0 # Can remove with access-nri-intake==0.0.9
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - nodejs
@@ -42,7 +41,7 @@ dependencies:
 - esmvaltool-ncl
 - scikit-image
 - jupyter
-- jupyterlab=3.6.4
+- jupyterlab
 - jupyterlab_server
 - jupyter_nbextensions_configurator
 - jupyter_contrib_nbextensions

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -27,8 +27,8 @@ dependencies:
 - iris-esmf-regrid
 - intake
 - access-nri-intake==0.0.8 # Keep pinned to latest version while in development
-# - intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
-# - ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
+- intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
+- ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
 - pydantic<2.0 # Can remove with access-nri-intake==0.0.9
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - nodejs
@@ -49,7 +49,7 @@ dependencies:
 - jupyter-server-proxy
 - jupyter-book
 - jupyter-resource-usage
-# - jsonschema>=4.18.1
+- jsonschema>=4.18.1
 - greenlet ### Dependency of... something?
 - objgraph ### Unlisted dependency of greenlet
 - asyncssh

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -27,8 +27,8 @@ dependencies:
 - iris-esmf-regrid
 - intake
 - access-nri-intake==0.0.8 # Keep pinned to latest version while in development
-- intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
-- ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
+# - intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
+# - ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
 - pydantic<2.0 # Can remove with access-nri-intake==0.0.9
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - nodejs

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -27,8 +27,8 @@ dependencies:
 - iris-esmf-regrid
 - intake
 - access-nri-intake==0.0.8 # Keep pinned to latest version while in development
-- intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
-- ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
+# - intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
+# - ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
 - pydantic<2.0 # Can remove with access-nri-intake==0.0.9
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - nodejs
@@ -49,7 +49,7 @@ dependencies:
 - jupyter-server-proxy
 - jupyter-book
 - jupyter-resource-usage
-# - jsonschema>=4.18.1
+- jsonschema>=4.18.1
 - greenlet ### Dependency of... something?
 - objgraph ### Unlisted dependency of greenlet
 - asyncssh

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -16,7 +16,6 @@ dependencies:
 - cdo>=1.9.5 # pinned for solver stability
 # pinning matplotlib to 3.5.3 temporarily until plotnine issue is fixed https://github.com/has2k1/plotnine/issues/620
 - matplotlib==3.5.3  #
-- pydantic<2.0 # Until https://github.com/intake/intake-esm/pull/619 is fixed
 - jinja2
 - ilamb
 - dask
@@ -28,6 +27,9 @@ dependencies:
 - iris-esmf-regrid
 - intake
 - access-nri-intake==0.0.8 # Keep pinned to latest version while in development
+- intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
+- ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
+- pydantic<2.0 # Can remove with access-nri-intake==0.0.9
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - nodejs
 - numpy>=1.21, !=1.24.3  # severe masking bug
@@ -47,6 +49,7 @@ dependencies:
 - jupyter-server-proxy
 - jupyter-book
 - jupyter-resource-usage
+- jsonschema>=4.18.1
 - greenlet ### Dependency of... something?
 - objgraph ### Unlisted dependency of greenlet
 - asyncssh

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -58,6 +58,7 @@ dependencies:
 - mpi4py
 - esmf
 - esmpy
+- pytest-json-report
 - xesmf >=0.7.1
 - xarray >=0.12.0
 - shapely

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -49,7 +49,7 @@ dependencies:
 - jupyter-server-proxy
 - jupyter-book
 - jupyter-resource-usage
-- jsonschema>=4.18.1
+# - jsonschema>=4.18.1
 - greenlet ### Dependency of... something?
 - objgraph ### Unlisted dependency of greenlet
 - asyncssh

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -49,7 +49,7 @@ dependencies:
 - jupyter-server-proxy
 - jupyter-book
 - jupyter-resource-usage
-- jsonschema>=4.18.1
+# - jsonschema>=4.18.1
 - greenlet ### Dependency of... something?
 - objgraph ### Unlisted dependency of greenlet
 - asyncssh
@@ -58,7 +58,7 @@ dependencies:
 - mpi4py
 - esmf
 - esmpy
-- pytest-json-report
+- pytest-json-report # needed by esmf and esmfpy
 - xesmf >=0.7.1
 - xarray >=0.12.0
 - shapely

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -22,7 +22,7 @@ export APPS_OWNERS_GROUP=xp65_w
 
 ### Version settings
 export ENVIRONMENT=access-med
-export VERSION_TO_MODIFY=0.1
+export VERSION_TO_MODIFY=0.2
 export STABLE_VERSION=0.1
 export UNSTABLE_VERSION=0.2
 export FULLENV="${ENVIRONMENT}-${VERSION_TO_MODIFY}"


### PR DESCRIPTION
Closes #44

I've also pinned some package versions so that the access-nri-intake catalog should work. These can be removed with the next release of `access-nri-intake` (>=0.0.9)