### PR TITLE
Update access-nri-intake to v0.0.9

### DIFF
--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -27,11 +27,8 @@ dependencies:
 - iris>=3.1.0
 - iris-esmf-regrid
 - intake
-- access-nri-intake==0.0.8 # Keep pinned to latest version while in development
-- intake-esm<2023.7.7 # Can remove with access-nri-intake==0.0.9
-- ecgtools<2023.7.13 # Can remove with access-nri-intake==0.0.9
+- access-nri-intake==0.0.9 # Keep pinned to latest version while in development
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
-- pydantic<2.0 # Can remove with access-nri-intake==0.0.9
 - nodejs
 - numpy>=1.21, !=1.24.3  # severe masking bug
 - pandas


### PR DESCRIPTION
Updates to `access-nri-intake=0.0.9` and removes a few pins that are no longer necessary