### PR TITLE
Update access nri intake

### DIFF
--- a/environments/access-med/environment.yml
+++ b/environments/access-med/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 - iris-esmf-regrid
 - iris-grib
 - intake
-- access-nri-intake==0.0.9 # Keep pinned to latest version while in development
+- access-nri-intake>=0.1.1
 - netcdf4<=1.6.0 ### Workaround for https://github.com/pydata/xarray/issues/7079
 - mo_pack
 - nodejs


### PR DESCRIPTION
Updates `access-nri-intake`. Note that this will have the effect of downgrading intake from 2.0.3 to 0.7.0.

Closes #77