### PR TITLE
Test Moving to python > 3.10

### DIFF
--- a/environments/access-med/environment.yml
+++ b/environments/access-med/environment.yml
@@ -7,7 +7,7 @@ variables:
 dependencies:
 - apscheduler
 - fs
-- python>=3.9
+- python>=3.10
 - libnetcdf=*=mpi_openmpi* # pinned for solver stability
 - pip
 - pytest >=3.9,!=6.0.0rc1,!=6.0.0


### PR DESCRIPTION
Planning on following SPEC0. Python 3.9 is not supported anymore.