### PR TITLE
add [complete] optional dependencies to xarray in conda environment

### DIFF
--- a/environments/access-med/environment.yml
+++ b/environments/access-med/environment.yml
@@ -58,7 +58,7 @@ dependencies:
 - esmpy
 - pytest-json-report ### Needed for esmpy
 - xesmf >=0.7.1
-- xarray >=0.12.0
+- xarray[complete] >=0.12.0
 - shapely
 - cf_xarray
 - sparse


### PR DESCRIPTION
Closes #123 .

This just adds [complete] to the xarray dependency in environment.yaml, and should fix the cftime issues.