### PR TITLE
Promote access-nri-intake to 1.0.0b2 in analysis3

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -272,7 +272,7 @@ dependencies:
 - cmor
 - bargeparse
 - accessnri::amami
-- accessnri::access-nri-intake==1.0.0b1
+- accessnri::access-nri-intake==1.0.0b2
 - ipynbname
 - shellcheck
 - pysteps


### PR DESCRIPTION
This PR is in prep to update the `analysis3` environment to use the new beta release of `access-nri-intake-catalog` `v1.0.0b2`.