### PR TITLE
Promote access_nri_intake to v1.0.0b3

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -272,7 +272,7 @@ dependencies:
 - cmor
 - bargeparse
 - accessnri::amami
-- accessnri::access-nri-intake==1.0.0b1
+- accessnri::access-nri-intake==1.0.0b3
 - ipynbname
 - shellcheck
 - pysteps


### PR DESCRIPTION
`access-nri-intake-catalog` v1.0.0b3 has built successfully - please add to `analysis3-24.11` and `analysis3-24.12` environments.