### PR TITLE
Update micromamba source in initialise.sh for compatibility with nb_c…

### DIFF
--- a/scripts/initialise.sh
+++ b/scripts/initialise.sh
@@ -17,10 +17,8 @@ function inner() {
 
     mkdir -p "${CONDA_INSTALLATION_PATH}"
     pushd "${CONDA_INSTALLATION_PATH}"
-    ### Romain Dec 2024, revert to latest micromamba
-    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-    ### Modified micromamba for compatibility with nb_conda_kernels
-    #curl -Ls https://dsroberts.github.io/mamba/latest | tar -xvj bin/micromamba bin/activate
+    ### Romain Sep 2025: Use micromamba from ACCESS-NRI repo (patch to work with nb_conda_kernels)
+    curl -Ls https://access-nri.github.io/mamba/latest | tar -xvj bin/micromamba bin/activate
 
     popd
 


### PR DESCRIPTION
This pull request updates the installation source for `micromamba` in the `scripts/initialise.sh` script to use a patched version from the ACCESS-NRI repository, ensuring compatibility with `nb_conda_kernels`.

Dependency source update:

* Changed the `curl` command to download `micromamba` and `activate` from `https://access-nri.github.io/mamba/latest` instead of the official micromamba API, applying a patch for compatibility with `nb_conda_kernels`