### PR TITLE
Update environment variable paths in common_v3

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -48,5 +48,5 @@ setenv ENV_LAUNCHER_SCRIPT_PATH /g/data/xp65/public/apps/med_conda_scripts/$cond
 ### Set the path to the cartopy pre existing data
 setenv CARTOPY_DATA_DIR /g/data/xp65/public/apps/cartopy-data
 ### Set configuration for the Rapid Evaluation Framework
-setenv REF_DATASET_CACHE_DIR="/scratch/$PROJECT/climate-ref-cache"
-setenv REF_CONFIGURATION="/g/data/xp65/public/apps/climate-ref"
+setenv REF_DATASET_CACHE_DIR /scratch/xp65/climate-ref-cache
+setenv REF_CONFIGURATION /g/data/xp65/public/apps/climate-ref


### PR DESCRIPTION
This pull request makes a minor adjustment to the environment variable configuration for the Rapid Evaluation Framework in the `modules/common_v3` file. The change updates the cache directory path to use a fixed project name instead of a variable, improving consistency and reliability.