### PR TITLE
Update catalog & ecgtools

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - cmor==3.9.*
   - accessnri::access-nri-intake==1.4.1
   - accessnri::intake-esm-access==2025.9.18
-  - accessnri::ecgtools>=2025.10.7
+  - accessnri::ecgtools-access>=2025.10.7
   - accessnri::access-py-telemetry==0.1.9
   - accessnri::access-intake-utils==0.1.7
   - conda-forge::intake-dataframe-catalog==0.4.0


### PR DESCRIPTION
- Update access_nri_intake to v1.4.1
- Pin to an ecgtools version where we can build catalogs with parquet instead of csv