### PR TITLE
Update dask configuration via environment variables in analysis3

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -41,6 +41,14 @@ setenv CONDA_EXE $prefix/$package/bin/micromamba
 
 ### Set Python path for Dask PBSCluster
 setenv DASK_JOBQUEUE__PBS__PYTHON /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/python
+### And some other related dask stuff - increase default chunk size to 300MiB
+setenv DASK_ARRAY__CHUNK_SIZE 300MiB
+### One thread per worker - segfault issues
+setenv DASK_DISTRIBUTED__WORKER_THREADS_PER_WORKER 1
+### Disable memory limit for workers - see https://coecms.github.io/posts/2023-09-20-dask-optimiser.html#removed-memory-worker-limit
+setenv DASK_DISTRIBUTED__WORKER__MEMORY__LIMIT None
+
+
 ### Set the path to the benchcab utility
 setenv BENCHCAB_PATH /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/benchcab
 ### Set launcher script path for payu


### PR DESCRIPTION
See: https://coecms.github.io/posts/2023-09-20-dask-optimiser.html

Sets: 
- Default chunk size to 300MiB, up from default of 128MiB
- 1 thread per worker by default - we've been advising everyone to do this anyway to avoid segfaults (eg. [here](https://forum.access-hive.org.au/t/netcdf-not-a-valid-id-errors/389)
- Turn off worker memory limit: see coecms blog post above.

