### PR TITLE
Revert changes from dask-optimiser module

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -41,13 +41,6 @@ setenv CONDA_EXE $prefix/$package/bin/micromamba
 
 ### Set Python path for Dask PBSCluster
 setenv DASK_JOBQUEUE__PBS__PYTHON /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/python
-### And some other related dask stuff - increase default chunk size to 300MiB
-setenv DASK_ARRAY__CHUNK_SIZE 300MiB
-### One thread per worker - segfault issues
-setenv DASK_DISTRIBUTED__WORKER_THREADS_PER_WORKER 1
-### Disable memory limit for workers - see https://coecms.github.io/posts/2023-09-20-dask-optimiser.html#removed-memory-worker-limit
-setenv DASK_DISTRIBUTED__WORKER__MEMORY__LIMIT None
-
 
 ### Set the path to the benchcab utility
 setenv BENCHCAB_PATH /g/data/xp65/public/apps/med_conda_scripts/$condaenv.d/bin/benchcab


### PR DESCRIPTION
I added a few environment variables from https://coecms.github.io/posts/2023-09-20-dask-optimiser.html#removed-memory-worker-limit recently.

These should have been 'safe' (ie. unlikely to cause any issues), but it sounds like I've been a touch too gung-ho about this.

Reverts 901d92c329fce5a3b5410556a18a3bbc23120db5 / #327 

cc. @jemmajeffree