### PR TITLE
Update esmvalcore and esmvaltool versions to 2.13

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -95,7 +95,7 @@ dependencies:
   - erddapy
   - esmf
   - esmpy
-  - esmvalcore
+  - esmvalcore==2.13.*
   - f90nml
   - ffmpeg
   - filelock
@@ -266,7 +266,7 @@ dependencies:
     - pycnv
 
 # Needed for ESMValTool merge
-  - esmvaltool==2.12.*
+  - esmvaltool==2.13.*
   - cdsapi
   - curl<8.10
   - importlib_metadata<8 # https://github.com/ESMValGroup/ESMValTool/issues/3699 only for Python 3.10/11 and esmpy<8.6


### PR DESCRIPTION
This pull request updates the version constraints for two dependencies in the `environments/analysis3/environment.yml` file to ensure compatibility with the latest releases of ESMValTool and esmvalcore.

Dependency version updates:

* Changed the `esmvalcore` dependency to require version `2.13.*` instead of an unconstrained version.
* Updated the `esmvaltool` dependency to require version `2.13.*` instead of `2.12.*`.