### PR TITLE
Update access-mopper package to access-moppy

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - conda-forge::intake-dataframe-catalog==0.4.0
   - accessnri::yamanifest>=0.3.12
   - accessnri::access-med-tools==0.1.23
-  - accessnri::access-moppy==1.0.0a*
+  - accessnri::access-moppy==1.0.0a4
   - accessnri::mule
   - accessnri::um-packing
   - accessnri::mule-utils


### PR DESCRIPTION
This pull request updates a dependency in the `environments/analysis3/environment.yml` file, replacing `access-mopper` with the new `access-moppy` package.

Dependency update:

* Replaced `accessnri::access-mopper==2.3.0a24` with `accessnri::access-moppy==1.0.0a*` in the environment dependencies.