### PR TITLE
analysis3-edge-25.11

### DIFF
--- a/environments/analysis3-edge/config.sh
+++ b/environments/analysis3-edge/config.sh
@@ -8,9 +8,9 @@
 ### outside_files_to_copy
 
 ### Optional config for custom deploy script
-export VERSION_TO_MODIFY=25.10
-export STABLE_VERSION=25.09
-export UNSTABLE_VERSION=25.10
+export VERSION_TO_MODIFY=25.11
+export STABLE_VERSION=25.10
+export UNSTABLE_VERSION=25.11
 
 ### Version settings
 export ENVIRONMENT=analysis3_edge
@@ -22,5 +22,3 @@ export CONDA_OVERRIDE_CUDA=12
 declare -a rpms_to_remove=( "openssh-clients" "openssh-server" "openssh" )
 declare -a replace_from_apps=( "ucx/1.15.0" openmpi/5.9.5)
 declare -a outside_commands_to_include=( "pbs_tmrsh" "ssh" )
-#declare -a outside_files_to_copy=( "/g/data/xp65/public/apps/openmpi/4.1.6" )
-#declare -a replace_with_external=( "/g/data/xp65/public/apps/openmpi/4.1.6" )

--- a/environments/analysis3-edge/environment.yml
+++ b/environments/analysis3-edge/environment.yml
@@ -5,17 +5,17 @@ channels:
 dependencies:
 # SPEC0 packages
 - python==3.11.*
-- dask==2025.9.*
+- dask==2025.10.*
 - numpy>=2.0
 - scipy==1.15.*
-- matplotlib>3.9
+- matplotlib>3.10
 - pandas==2.3.*
 - scikit-image==0.25.*
 - scikit-learn==1.7.*
-- xarray==2025.9.*
+- xarray==2025.10.1
 - ipython<9.0
 - zarr>3.0
-- iris==3.12.*
+- iris==3.13.*
 - netcdf4==1.7.*
 - libnetcdf=*=mpi_openmpi*
 - openmpi==5.0.5


### PR DESCRIPTION
This pull request updates the `analysis3-edge` environment to use newer versions of several core scientific Python packages and increments the environment version numbers in the configuration. The changes ensure the environment stays current with recent package releases and maintains compatibility with upstream updates.

Dependency updates:

* Updated `dask` to version `2025.10.*` to ensure the environment uses the latest features and bug fixes.
* Updated `matplotlib` to require versions greater than `3.10` (previously `>3.9`).
* Updated `xarray` to version `2025.10.1` (from `2025.9.*`).
* Updated `iris` to version `3.13.*` (from `3.12.*`).

Environment version management:

* Incremented `VERSION_TO_MODIFY`, `STABLE_VERSION`, and `UNSTABLE_VERSION` in `config.sh` to `25.11`, `25.10`, and `25.11` respectively, reflecting the new environment version.