### PR TITLE
Add pip dependency for ilamb3 from GitHub

### DIFF
--- a/environments/analysis3-edge/environment.yml
+++ b/environments/analysis3-edge/environment.yml
@@ -217,3 +217,6 @@ dependencies:
 - xrft
 - xskillscore
 - xwrf
+
+- pip:
+  - git+https://github.com/rubisco-sfa/ilamb3@v2025.9.9


### PR DESCRIPTION
This pull request makes a small change to the `environment.yml` file for the `analysis3-edge` environment by adding the `ilamb3` package from a specific GitHub repository via pip.Add install for ILAMB3