### PR TITLE
Implement check_analysis3_age function

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -1,5 +1,45 @@
 #%Module1.0
 
+# Function: check_analysis3_age
+# Supports conda/analysis3-YY.MM and conda/analysis3-edge-YY.MM
+proc check_analysis3_age {} {
+    # Get full module name, e.g. "conda/analysis3-25.08" or "conda/analysis3-edge-25.08"
+    set modname [module-info name]
+
+    # Match both stable and edge variants
+    if { [regexp {analysis3(?:-edge)?-(\d{2})\.(\d{2})} $modname -> yy mm] } {
+        # Parse version numbers as decimal (avoid octal issue)
+        set year [expr {2000 + [scan $yy %d]}]
+        set month [scan $mm %d]
+
+        # Current date
+        set now [clock seconds]
+        set current_year [scan [clock format $now -format %Y] %d]
+        set current_month [scan [clock format $now -format %m] %d]
+
+        # Convert both to "months since year 0"
+        set current_total_months [expr {$current_year * 12 + $current_month}]
+        set env_total_months [expr {$year * 12 + $month}]
+        set diff_months [expr {$current_total_months - $env_total_months}]
+
+        # Warn if too old, or notify if from the future
+        if { $diff_months > 6 } {
+            puts stderr "\033\[1;33mWARNING:\033\[0m The environment '$modname' is more than $diff_months months old."
+            puts stderr "It will soon be deprecated. Please move to a newer 'conda/analysis3' environment."
+        } elseif { $diff_months < -1 } {
+            puts stderr "\033\[1;33mNOTICE:\033\[0m The environment '$modname' appears to be from the future ($year-$month)."
+            puts stderr "Please verify that you have loaded the correct module."
+        }
+    } else {
+        puts stderr "Note: Could not determine environment version from module name '$modname'."
+    }
+}
+
+# Run the check only when module is being loaded
+if { [module-info mode load] } {
+    check_analysis3_age
+}
+
 #set-basedir -root __CONDA_BASE__/__APPS_SUBDIR__ -package __CONDA_INSTALL_BASENAME__ -version envs/$::version
 set prefix __CONDA_BASE__/__APPS_SUBDIR__
 set package __CONDA_INSTALL_BASENAME__


### PR DESCRIPTION
This pull request adds a new feature to the `modules/common_v3` module to improve user awareness about the age of loaded `conda/analysis3` environments. The main change is the introduction of a version check that warns users if their environment is outdated or not recognised.

**Environment age check feature:**

* Added the `check_analysis3_age` procedure to parse the module name, extract the environment version, and compare it to the current date. This procedure warns the user if the environment is more than six months old or notifies them if it appears to be from the future.
* Integrated the age check to run automatically when the module is loaded, ensuring users receive immediate feedback about their environment version. Added a function to check the age of the analysis3 conda environment and provide warnings or notices based on its version.