### PR TITLE
Update numpy version and remove wrf-python dependency

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python==3.11.*
+  - python==3.12.*
   - dask==2025.10.*
   - numpy>=2.0
   - scipy==1.16.*


### PR DESCRIPTION
Dependency version updates:

* Updated the `numpy` dependency from a fixed version (`1.26.*`) to a more flexible and recent version (`>=2.0`) to support newer features and broader compatibility.

Dependency removals:

* Removed the `wrf-python` package from the environment (we know it does not support numpy 2.0)