### PR TITLE
Add mplotutils (private forum help request)

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -153,6 +153,7 @@ dependencies:
   - moderngl
   - mpi4py
   - mpl-scatter-density
+  - mplotutils
   - mplleaflet
   - mscorefonts
   - nbdime


### PR DESCRIPTION
From [mplotutils/pyproject.toml](https://github.com/mpytools/mplotutils/blob/main/pyproject.toml): 

```toml
dependencies = [
    "cartopy >=0.23",
    "matplotlib >=3.9",
    "packaging >= 23.1",
    "numpy >=1.26",
    "xarray >=2024.7",
]
```

I think we should be safe to add this thanks to the lack of upper pins.
