### PR TITLE
Replace accessnri::ucx-py with rapidsai::ucx-py in environment.yml

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -232,7 +232,7 @@ dependencies:
   - tqdm
   - twine
   - u8darts-all
-  - accessnri::ucx-py
+  - rapidsai::ucx-py
   - ucx==1.15.0
   - ultraplot
   - ujson


### PR DESCRIPTION
Some update @charles-turner-1 

So rapidsai started publishing conda package for Python >3.11 about a year ago, just after Dale built a package for us.

Version 0.40 requires UCX>1.15.0,<1.18.0
Version 0.45 requires UCX>1.15.0,<1.19.0

Gadi has now UCX 1.15, 1.17 and 1.18.1

I think we can switch to the rapidsai conda channel for this one.
I am keeping UCX 1.15 for analysis3-25.11, will update for analysis3-25.12

Now we need to check which package requires ucx-py so we can start looking at the migration to UCXX.