### PR TITLE
Remove conda-verify from environment.yml

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -72,7 +72,6 @@ dependencies:
   - conda-build
   - conda-lock
   - conda-tree
-  - conda-verify
   - crick
   - cupy
   - cvxpy


### PR DESCRIPTION
Removed 'conda-verify' from the environment dependencies.

conda-verify is unmaintained since end of 2019 and is basically broken for python>3.10