### PR TITLE
Configure Open MPI environment variables and paths

### DIFF
--- a/modules/common_v3
+++ b/modules/common_v3
@@ -93,3 +93,28 @@ setenv REF_DATASET_CACHE_DIR /scratch/xp65/climate-ref-cache
 setenv REF_CONFIGURATION /g/data/xp65/public/apps/climate-ref
 ### Add uqstat 
 prepend-path PATH /g/data/xp65/public/apps/nci_scripts
+
+# Fix Open MPI relocation (moved from hh5 -> xp65)
+set root /g/data/xp65/public/apps/openmpi/4.1.6
+
+setenv OPAL_PREFIX $root
+prepend-path PATH $root/bin
+
+# Libraries (add whichever exists)
+if { [file isdirectory $root/lib] } {
+    prepend-path LD_LIBRARY_PATH $root/lib
+}
+if { [file isdirectory $root/lib64] } {
+    prepend-path LD_LIBRARY_PATH $root/lib64
+}
+
+# Nice-to-have
+if { [file isdirectory $root/share/man] } {
+    prepend-path MANPATH $root/share/man
+}
+if { [file isdirectory $root/lib/pkgconfig] } {
+    prepend-path PKG_CONFIG_PATH $root/lib/pkgconfig
+}
+if { [file isdirectory $root/lib64/pkgconfig] } {
+    prepend-path PKG_CONFIG_PATH $root/lib64/pkgconfig
+}


### PR DESCRIPTION
This pull request updates the `modules/common_v3` environment module to properly configure the Open MPI installation after its relocation from the `hh5` to `xp65` filesystem. The changes ensure that all relevant environment variables and paths are set for Open MPI to function correctly.

Note that I have used this approach to avoid having to recompile the executable which could have caused back compatibility issues. 

Open MPI relocation and environment configuration:

* Added logic to set the `OPAL_PREFIX` environment variable and update the `PATH` to include the new Open MPI binary directory (`/g/data/xp65/public/apps/openmpi/4.1.6/bin`).
* Updated the `LD_LIBRARY_PATH` to include either `lib` or `lib64` directories from the new Open MPI location, depending on which exists.
* Enhanced the module to prepend `MANPATH` and `PKG_CONFIG_PATH` with the appropriate Open MPI directories if they exist, improving usability for developers.Added environment variables and paths for Open MPI relocation.
