### PR TITLE
Update benchcab to 4.3.1

### DIFF
--- a/environments/benchcab/config.sh
+++ b/environments/benchcab/config.sh
@@ -1,6 +1,6 @@
 # Note: BENCHCAB_VERSION should match the version of benchcab in
 # environments/benchcab/environment.yml:
-BENCHCAB_VERSION=4.3.0
+BENCHCAB_VERSION=4.3.1
 export ENVIRONMENT="benchcab"
 export STABLE_VERSION="${BENCHCAB_VERSION}"
 export FULLENV="${ENVIRONMENT}-${BENCHCAB_VERSION}"

--- a/environments/benchcab/environment.yml
+++ b/environments/benchcab/environment.yml
@@ -6,5 +6,5 @@ channels:
 dependencies:
 # Note: the pinned benchcab version should match the BENCHCAB_VERSION
 # environment variable in environments/benchcab/config.sh:
-- accessnri::benchcab==4.3.0
+- accessnri::benchcab==4.3.1
 - accessnri::payu>=1.1.7


### PR DESCRIPTION
The OPAL_PREFIX environment variable introduced in PR #352 causes the xp65 MPI library to take precedence over any MPI libraries loaded via module load - as a workaround, this change unsets this variable from the build environment to fix this issue.

References https://github.com/CABLE-LSM/benchcab/pull/341