### PR TITLE
Update ACCESS-MOPPy to latest

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -12,8 +12,8 @@ dependencies:
   - access-intake-esm=2026.4.19=py_0
   - access-intake-utils=0.1.7=py_0
   - access-med-tools=0.1.23=pypy_0
-  - access-moppy=1.3.0b=py_0
-  - access-moppy-esmval=1.3.0b=0
+  - access-moppy=1.4.1b=py_0
+  - access-moppy-esmval=1.4.1b=0
   - access-nri-intake=1.6.0=py_0
   - access-py-telemetry=0.1.10=py_0
   - accessible-pygments=0.0.5=pyhd8ed1ab_1


### PR DESCRIPTION
This pull request updates the versions of the `access-moppy` and `access-moppy-esmval` dependencies in the `environments/analysis3/environment.yml` file to newer releases. No other changes are included.

- Dependency updates:
  * Upgraded `access-moppy` from version `1.3.0b` to `1.4.1b`.
  * Upgraded `access-moppy-esmval` from version `1.3.0b` to `1.4.1b`.