### PR TITLE
Add xwmb, closes #445

### DIFF
--- a/environments/analysis3/README.md
+++ b/environments/analysis3/README.md
@@ -46,6 +46,17 @@ pixi run rebuild-env
 
 That task handles the lock/update flow and regenerates `environment.yml` for you.
 
+On macOS, add `--as-is`:
+
+```bash
+pixi run --as-is rebuild-env
+```
+
+The workspace only targets `linux-64`, so a plain `pixi run` fails with `unsupported-platform`
+when it tries to activate the environment. `--as-is` skips that activation; the task itself only
+needs the `pixi` binary and `grep`, and it renders `linux-64` explicitly, so the output is
+byte-identical to a Linux run.
+
 If you wanted to use pixi shell at this point, instead of creating a pixi environment, you could do:
 ```bash
 pixi shell

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1,4 +1,4 @@
-name: default
+name: analysis3
 channels:
 - conda-forge
 - accessnri

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -22,7 +22,6 @@ dependencies:
 - intake-virtual-icechunk ==0.2.2 py_0
 - yamanifest ==0.3.13 py_0
 - pygamma_n ==1.0.0 py312h4cfd3ad_1
-- _openmp_mutex ==4.5 7_kmp_llvm
 - aiohttp ==3.14.1 py312h5d8c7f2_0
 - alsa-lib ==1.2.16.1 hb03c661_0
 - aom ==3.9.1 hac33072_0
@@ -703,9 +702,6 @@ dependencies:
 - zlib-ng ==2.2.5 hde8ca8f_1
 - zstandard ==0.25.0 py312h5253ce2_1
 - zstd ==1.5.7 hb78ec9c_6
-- _python_abi3_support ==1.0 hd8ed1ab_2
-- _r-mutex ==1.0.1 anacondar_1
-- _x86_64-microarch-level ==1 4_level1
 - absl-py ==2.5.0 pyhd8ed1ab_0
 - access ==1.1.10.post3 pyhd8ed1ab_0
 - accessible-pygments ==0.0.5 pyhd8ed1ab_1
@@ -1488,3 +1484,4 @@ dependencies:
   - sqlmodel==0.0.39
   - cc-plugin-wcrp==2.3.2
   - cmip7-data-request-api==1.4
+

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1,1480 +1,1485 @@
-name: analysis3
+name: default
 channels:
-  - accessnri
-  - conda-forge
-  - nodefaults
-  - rapidsai
-  - pytorch
-  - nvidia
-  - conda-forge/label/broken
+- conda-forge
+- accessnri
+- nodefaults
+- rapidsai
+- pytorch
+- nvidia
+- conda-forge/label/broken
+- nodefaults
 dependencies:
-  - absl-py=2.5.0=pyhd8ed1ab_0
-  - access=1.1.10.post3=pyhd8ed1ab_0
-  - access-intake-esm=2026.7.1=py_0
-  - access-intake-utils=0.1.7=py_0
-  - access-med-tools=0.1.23=pypy_0
-  - access-moppy=1.6.6b=py_0
-  - access-moppy-esmval=1.6.6b=0
-  - access-nri-intake=1.6.2=py_0
-  - access-py-telemetry=0.1.10=py_0
-  - accessible-pygments=0.0.5=pyhd8ed1ab_1
-  - adagio=0.2.6=pyhd8ed1ab_1
-  - adwaita-icon-theme=49.0=unix_0
-  - affine=2.4.0=pyhd8ed1ab_1
-  - aiobotocore=3.7.0=pyhcf101f3_0
-  - aiohappyeyeballs=2.7.1=pyhd8ed1ab_0
-  - aiohttp=3.14.1=py312h5d8c7f2_0
-  - aiohttp-cors=0.8.1=pyhcf101f3_1
-  - aioitertools=0.13.0=pyhd8ed1ab_0
-  - aiosignal=1.4.0=pyhd8ed1ab_0
-  - alabaster=1.0.0=pyhd8ed1ab_1
-  - alembic=1.18.5=pyhcf101f3_0
-  - alsa-lib=1.2.16.1=hb03c661_0
-  - amply=0.1.7=pyhd8ed1ab_0
-  - annotated-doc=0.0.4=pyhcf101f3_0
-  - annotated-types=0.7.0=pyhd8ed1ab_1
-  - anyio=4.14.1=pyhcf101f3_0
-  - anytree=2.13.0=pyhcf101f3_1
-  - aom=3.9.1=hac33072_0
-  - appdirs=1.4.4=pyhd8ed1ab_1
-  - apptools=5.3.1=pyhe01879c_1
-  - arch-py=8.0.0=py312h4f23490_0
-  - archspec=0.2.5=pyhd8ed1ab_0
-  - argon2-cffi=25.1.0=pyhd8ed1ab_0
-  - argon2-cffi-bindings=25.1.0=py312h4c3975b_2
-  - argopy=1.3.1=pyhd8ed1ab_0
-  - arm_pyart=2.2.4=py312h4c3975b_0
-  - arrow=1.4.0=pyhcf101f3_0
-  - arviz=1.2.0=pyhc364b38_0
-  - arviz-base=1.2.0=pyhd8ed1ab_0
-  - arviz-plots=1.2.0=pyhc364b38_0
-  - arviz-stats=1.2.0=pyh8e99733_0
-  - arviz-stats-core=1.2.0=pyhc364b38_0
-  - asteval=1.0.9=pyhd8ed1ab_0
-  - astroid=4.0.4=py312h7900ff3_0
-  - astropy=8.0.0=pyhd8ed1ab_0
-  - astropy-base=8.0.0=py312h4f23490_0
-  - astropy-iers-data=0.2026.6.22.1.23.34=pyhd8ed1ab_0
-  - asttokens=3.0.1=pyhd8ed1ab_0
-  - astunparse=1.6.3=pyhd8ed1ab_3
-  - async-lru=2.3.0=pyhcf101f3_0
-  - asyncssh=2.23.0=pyhd8ed1ab_0
-  - at-spi2-atk=2.38.0=h0630a04_3
-  - at-spi2-core=2.40.3=h0630a04_0
-  - atk-1.0=2.38.0=h04ea711_2
-  - attrdict=2.0.1=py_0
-  - attrs=26.1.0=pyhcf101f3_0
-  - autodocsumm=0.2.15=pyhd8ed1ab_0
-  - autopage=0.6.0=pyhd8ed1ab_0
-  - autopep8=2.3.2=pyhd8ed1ab_0
-  - av=15.1.0=py312hdd571cc_0
-  - aws-c-auth=0.8.6=hd08a7f5_4
-  - aws-c-cal=0.8.7=h043a21b_0
-  - aws-c-common=0.12.0=hb9d3cd8_0
-  - aws-c-compression=0.3.1=h3870646_2
-  - aws-c-event-stream=0.5.4=h04a3f94_2
-  - aws-c-http=0.9.4=hb9b18c6_4
-  - aws-c-io=0.17.0=h3dad3f2_6
-  - aws-c-mqtt=0.12.2=h108da3e_2
-  - aws-c-s3=0.7.13=h822ba82_2
-  - aws-c-sdkutils=0.2.3=h3870646_2
-  - aws-checksums=0.2.3=h3870646_2
-  - aws-crt-cpp=0.31.0=h55f77e1_4
-  - aws-sdk-cpp=1.11.510=h37a5c72_3
-  - azure-core-cpp=1.14.0=h5cfcd09_0
-  - azure-identity-cpp=1.10.0=h113e628_0
-  - azure-storage-blobs-cpp=12.13.0=h3cf044e_1
-  - azure-storage-common-cpp=12.8.0=h736e048_1
-  - azure-storage-files-datalake-cpp=12.12.0=ha633028_1
-  - babel=2.18.0=pyhcf101f3_1
-  - backports=1.0=pyhd8ed1ab_5
-  - backports.tarfile=1.2.0=pyhcf101f3_2
-  - backports.zoneinfo=0.2.1=py312h7900ff3_11
-  - backports.zstd=1.6.0=py312h90b7ffd_0
-  - banal=1.0.6=pyhd8ed1ab_1
-  - bargeparse=0.9.1=pyhd8ed1ab_0
-  - base58=2.1.1=pyhd8ed1ab_1
-  - beautifulsoup4=4.15.0=pyha770c72_0
-  - bias_correction=0.4=pyhd8ed1ab_0
-  - binutils_impl_linux-64=2.45.1=default_hfdba357_102
-  - binutils_linux-64=2.45.1=default_h4852527_102
-  - black=26.5.1=pyh866005b_0
-  - blake3=1.0.9=py312h868fb18_0
-  - blas=1.0=mkl
-  - bleach=6.4.0=pyhcf101f3_0
-  - bleach-with-css=6.4.0=hac0b51c_0
-  - blinker=1.9.0=pyhff2d567_0
-  - blosc=1.21.6=he440d0b_1
-  - bokeh=3.9.1=pyhd8ed1ab_0
-  - boltons=26.0.0=pyhd8ed1ab_0
-  - botocore=1.43.0=pyhd8ed1ab_0
-  - bottleneck=1.6.0=np2py312hfb8c2c5_3
-  - bqplot=0.13.1=pyhcf101f3_0
-  - bqscales=0.3.7=pyhd8ed1ab_1
-  - branca=0.8.2=pyhd8ed1ab_0
-  - brotli=1.1.0=hb03c661_4
-  - brotli-bin=1.1.0=hb03c661_4
-  - brotli-python=1.1.0=py312h1289d80_4
-  - brunsli=0.1=he3183e4_1
-  - bwidget=1.10.1=ha770c72_1
-  - bzip2=1.0.8=hda65f42_9
-  - c-ares=1.34.6=hb03c661_0
-  - c-blosc2=2.17.1=h3122c55_0
-  - c-compiler=1.0.0=h14c3975_0
-  - ca-certificates=2026.6.17=hbd8a1cb_0
-  - cachecontrol=0.14.4=pyha770c72_0
-  - cachecontrol-with-filecache=0.14.4=pyhd8ed1ab_0
-  - cached-property=1.5.2=hd8ed1ab_1
-  - cached_property=1.5.2=pyha770c72_1
-  - cachetools=7.1.4=pyhd8ed1ab_0
-  - cairo=1.18.4=h3394656_0
-  - capnproto=1.0.2=h766bdaa_3
-  - cartopy=0.25.0=py312hf79963d_1
-  - catboost=1.2.10=cuda120_py312hd5f8c11_100
-  - cattrs=26.1.0=pyhcf101f3_1
-  - cdo=2.5.0=hc8165f4_0
-  - cdsapi=0.7.7=pyhd8ed1ab_0
-  - celluloid=0.2.0=pyhd8ed1ab_0
-  - certifi=2026.6.17=pyhd8ed1ab_0
-  - cf-python=3.20.0=py312h3111c9b_0
-  - cf-units=3.3.1=py312h4f23490_0
-  - cf-xarray=0.11.3=pyhd8ed1ab_0
-  - cf_xarray=0.11.3=pyhd8ed1ab_0
-  - cfchecker=4.1.0=pyhd8ed1ab_1
-  - cfdm=1.13.1.0=py312h7900ff3_0
-  - cffi=2.0.0=py312h460c074_1
-  - cfgrib=0.9.15.1=pyhd8ed1ab_0
-  - cfgv=3.5.0=pyhd8ed1ab_0
-  - cfitsio=4.5.0=h44b4e7a_0
-  - cftime=1.6.5=py312h4f23490_1
-  - cfunits=3.3.7=pyhd8ed1ab_1
-  - cgen=2025.1=pyhd8ed1ab_0
-  - chardet=7.4.3=pyhcf101f3_0
-  - charls=2.4.4=hecca717_0
-  - charset-normalizer=3.4.7=pyhd8ed1ab_0
-  - chart-studio=1.1.0=pyhd8ed1ab_1
-  - clarabel=0.11.1=py312h0ccc70a_2
-  - click=8.4.2=pyhc90fa1f_0
-  - click-default-group=1.2.4=pyhd8ed1ab_1
-  - click-plugins=1.1.1.2=pyhd8ed1ab_0
-  - cliff=4.14.0=pyhd8ed1ab_0
-  - cligj=0.7.2=pyhd8ed1ab_2
-  - climpred=2.6.0=pyhd8ed1ab_0
-  - cloudpickle=3.1.2=pyhcf101f3_1
-  - cmaps=2.0.1=pyhd8ed1ab_0
-  - cmcrameri=1.9=pyhd8ed1ab_1
-  - cmd2=3.5.1=py312h7900ff3_0
-  - cmdline_provenance=1.1.0=pyhd8ed1ab_1
-  - cmocean=4.0.3=pyhd8ed1ab_1
-  - cmor=3.10.0=py312h9ea2cd8_0
-  - cmweather=0.3.2=pyhd8ed1ab_1
-  - codespell=2.3.0=pyhd8ed1ab_1
-  - coin-or-cbc=2.10.13=h4d16d09_1
-  - coin-or-cgl=0.60.10=hc46dffc_1
-  - coin-or-clp=1.17.11=hc03379b_1
-  - coin-or-osi=0.108.12=hf4fecb4_1
-  - coin-or-utils=2.11.13=hc93afbd_1
-  - colorama=0.4.6=pyhd8ed1ab_1
-  - colorcet=3.2.1=pyhd8ed1ab_0
-  - colorspacious=1.1.2=pyhecae5ae_1
-  - comm=0.2.3=pyhe01879c_0
-  - compliance-checker=6.1.0=pyhd8ed1ab_0
-  - comrak=0.53.0=hb17b654_0
-  - conda=26.5.3=py312h20c3967_2
-  - conda-build=26.5.0=pyh31ec981_0
-  - conda-index=0.12.1=pyhd8ed1ab_0
-  - conda-libmamba-solver=26.6.0=pyhcf101f3_0
-  - conda-lock=4.0.2=pyha191276_0
-  - conda-lockfiles=0.2.0=pyhd8ed1ab_0
-  - conda-package-handling=2.5.0=pyhcf101f3_0
-  - conda-package-streaming=0.13.0=pyhd8ed1ab_0
-  - conda-pypi=0.11.0=py312h20c3967_0
-  - conda-rattler-solver=0.1.1=pyhcf101f3_0
-  - conda-self=0.2.0=pyhd8ed1ab_0
-  - conda-tree=1.2.0=pyhcf101f3_0
-  - config=0.5.1=pyhd8ed1ab_1
-  - configargparse=1.7.5=pyhcf101f3_0
-  - configobj=5.0.9=pyhd8ed1ab_1
-  - constantdict=2025.3=pyhcf101f3_1
-  - contextily=1.7.0=pyhd8ed1ab_0
-  - contourpy=1.3.3=py312h0a2e395_4
-  - coreforecast=0.0.17=py312hd9148b4_0
-  - coverage=7.15.0=py312h8a5da7c_0
-  - cpp-expected=1.1.0=hff21bea_1
-  - cpython=3.12.13=py312hd8ed1ab_0
-  - crashtest=0.4.1=pyhd8ed1ab_1
-  - crick=0.0.8=py312hc0a28a1_0
-  - cryptography=49.0.0=py312ha4b625e_0
-  - cuda-cccl_linux-64=12.4.127=ha770c72_2
-  - cuda-cudart=12.4.127=he02047a_2
-  - cuda-cudart-dev_linux-64=12.4.127=h85509e4_2
-  - cuda-cudart-static_linux-64=12.4.127=h85509e4_2
-  - cuda-cudart_linux-64=12.4.127=h85509e4_2
-  - cuda-cupti=12.4.127=he02047a_2
-  - cuda-libraries=12.4.1=ha770c72_1
-  - cuda-nvrtc=12.4.127=he02047a_2
-  - cuda-nvtx=12.4.127=he02047a_2
-  - cuda-opencl=12.4.127=he02047a_1
-  - cuda-runtime=12.4.1=ha804496_0
-  - cuda-version=12.4=h3060b56_3
-  - cupy=13.4.1=py312h78400a1_0
-  - cupy-core=13.4.1=py312h007fbcc_0
-  - curl=8.18.0=h4e3cde8_0
-  - cvxpy=1.9.1=py312h4f8cda9_0
-  - cvxpy-base=1.9.1=np2py312h0f77346_0
-  - cycler=0.12.1=pyhcf101f3_2
-  - cyrus-sasl=2.1.28=hd9c7081_0
-  - cython=3.2.8=py312h68e6be4_0
-  - cytoolz=1.1.0=py312h4c3975b_2
-  - dask=2026.1.2=pyhcf101f3_1
-  - dask-core=2026.1.2=pyhcf101f3_0
-  - dask-glm=0.3.2=pyhd8ed1ab_0
-  - dask-jobqueue=0.9.0=pyhd8ed1ab_0
-  - dask-labextension=7.0.0=pyhd8ed1ab_1
-  - dask-ml=2025.1.0=pyhd8ed1ab_0
-  - dask-xgboost=0.1.11=pyh9f0ad1d_0
-  - dataclasses-json=0.6.7=pyhcf101f3_2
-  - dataset=1.5.2=pyhd8ed1ab_0
-  - datashader=0.19.1=pyhd8ed1ab_0
-  - dateparser=1.4.1=pyhd8ed1ab_0
-  - dav1d=1.2.1=hd590300_0
-  - dbus=1.13.6=h5008d03_3
-  - dcw-gmt=2.2.0=ha770c72_0
-  - debtcollector=3.1.0=pyhd8ed1ab_0
-  - debugpy=1.8.21=py312h8285ef7_0
-  - decorator=5.3.1=pyhd8ed1ab_0
-  - defusedxml=0.7.1=pyhd8ed1ab_0
-  - deprecated=1.3.1=pyhd8ed1ab_1
-  - deprecation=2.1.0=pyh9f0ad1d_0
-  - descartes=1.1.0=pyhd8ed1ab_5
-  - dill=0.4.1=pyhcf101f3_0
-  - distlib=0.4.3=pyhcf101f3_0
-  - distributed=2026.1.2=pyhcf101f3_1
-  - distro=1.9.0=pyhd8ed1ab_1
-  - doc8=2.0.0=pyhd8ed1ab_0
-  - docformatter=1.7.5=pyhd8ed1ab_1
-  - docopt-ng=0.9.0=pyhd8ed1ab_1
-  - docrep=0.3.2=pyh44b312d_0
-  - docutils=0.21.2=pyhd8ed1ab_1
-  - dodgy=0.2.1=py_0
-  - dogpile.cache=1.3.3=pyhd8ed1ab_0
-  - donfig=0.8.1.post1=pyhd8ed1ab_1
-  - double-conversion=3.3.1=h5888daf_0
-  - dreqpy=1.2.0=pyhd8ed1ab_1
-  - dulwich=0.24.10=py312h0ccc70a_1
-  - earthpy=0.9.4=pyhd8ed1ab_0
-  - eccodes=2.41.0=h8bb6dbc_0
-  - ecgtools-access=2025.10.7=py_0
-  - ecmwf-api-client=1.7.0=pyhd8ed1ab_0
-  - ecmwf-datastores-client=0.5.1=pyhd8ed1ab_0
-  - emcee=3.1.6=pyhd8ed1ab_1
-  - ensureconda=1.6.0=pyhcf101f3_0
-  - entrypoints=0.4=pyhd8ed1ab_1
-  - envisage=7.0.4=pyhe01879c_1
-  - eofs=2.0.0=pyhff2d567_0
-  - epoxy=1.5.10=hb03c661_2
-  - erddapy=3.3.0=pyhc364b38_0
-  - esda=2.7.1=pyhd8ed1ab_0
-  - esgf-pyclient=0.3.1=pyhd8ed1ab_5
-  - esmf=8.8.1=mpi_openmpi_h461c5ee_0
-  - esmpy=8.8.1=pyhecae5ae_0
-  - esmvalcore=2.14.0=pyhc364b38_0
-  - esmvaltool=2.14.0=pyhe136c3f_0
-  - esmvaltool-ncl=2.14.0=hea5a5a1_0
-  - esmvaltool-python=2.14.0=pyhc364b38_0
-  - esmvaltool-r=2.14.0=hea5a5a1_0
-  - esmvaltool-sample-data=0.0.4=pyhd8ed1ab_0
-  - et_xmlfile=2.0.0=pyhd8ed1ab_1
-  - evalidate=2.0.5=pyhe01879c_0
-  - exceptiongroup=1.3.1=pyhd8ed1ab_0
-  - execnet=2.1.2=pyhd8ed1ab_0
-  - executing=2.2.1=pyhd8ed1ab_0
-  - expat=2.8.1=hecca717_1
-  - f90nml=1.5=pyhd8ed1ab_0
-  - fast-histogram=0.14=py312h4f23490_4
-  - fastprogress=1.0.3=pyhd8ed1ab_1
-  - fastrlock=0.8.3=py312h8285ef7_2
-  - ffmpeg=7.1.1=gpl_h0b79d52_704
-  - fftw=3.3.11=nompi_h3b011a4_100
-  - filelock=3.29.5=pyhd8ed1ab_0
-  - findlibs=0.1.2=pyhd8ed1ab_0
-  - fiona=1.10.1=py312h02b19dd_3
-  - fire=0.7.1=pyhd8ed1ab_0
-  - flake8=7.3.0=pyhd8ed1ab_0
-  - flake8-polyfill=1.0.2=pyhd8ed1ab_1
-  - flatbuffers=24.12.23=h8f4948b_0
-  - flexcache=0.3=pyhd8ed1ab_1
-  - flexparser=0.4=pyhd8ed1ab_1
-  - flox=0.11.2=pyhd8ed1ab_0
-  - fmt=11.0.2=h07f6e7f_1
-  - folium=0.20.0=pyhd8ed1ab_0
-  - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
-  - font-ttf-inconsolata=3.000=h77eed37_0
-  - font-ttf-source-code-pro=2.038=h77eed37_0
-  - font-ttf-ubuntu=0.83=h77eed37_3
-  - fontconfig=2.18.1=h27c8c51_0
-  - fonts-conda-ecosystem=1=0
-  - fonts-conda-forge=1=hc364b38_1
-  - fonttools=4.63.0=py312h8a5da7c_0
-  - fortran-language-server=1.12.0=pyhd8ed1ab_1
-  - fqdn=1.5.1=pyhd8ed1ab_1
-  - freeglut=3.2.2=h215f996_4
-  - freetype=2.14.3=ha770c72_0
-  - freexl=2.0.0=h9dce30a_2
-  - fribidi=1.0.16=hb03c661_0
-  - frozendict=2.4.7=pyh851646a_2
-  - frozenlist=1.8.0=py312h447239a_0
-  - fs=2.4.16=pyhd8ed1ab_0
-  - fsspec=2026.6.0=pyhd8ed1ab_0
-  - fugue=0.9.7=pyhcf101f3_0
-  - future=1.0.0=pyhd8ed1ab_2
-  - gast=0.7.0=pyhd8ed1ab_0
-  - gcc_impl_linux-64=15.2.0=he0086c7_19
-  - gcc_linux-64=15.2.0=h7be306e_27
-  - gcm_filters=0.5.1=pyhd8ed1ab_0
-  - gcsfs=2026.6.0=pyhd8ed1ab_0
-  - gdal=3.10.2=py312hc55c449_5
-  - gdk-pixbuf=2.42.12=hb9ae30d_0
-  - geocat-comp=2026.04.0=pyhd8ed1ab_0
-  - geocat-viz=2025.07.0=pyhd8ed1ab_1
-  - geographiclib=2.1=pyhd8ed1ab_0
-  - geopandas=1.1.4=pyhd8ed1ab_0
-  - geopandas-base=1.1.4=pyha770c72_0
-  - geoplot=0.5.1=pyhd8ed1ab_1
-  - geopy=2.4.1=pyhd8ed1ab_2
-  - geos=3.13.0=h5888daf_0
-  - geotiff=1.7.4=h3551947_0
-  - geoviews=1.14.0=hd8ed1ab_0
-  - geoviews-core=1.14.0=pyha770c72_0
-  - gettext=0.25.1=h3f43e3d_1
-  - gettext-tools=0.25.1=h3f43e3d_1
-  - gflags=2.2.2=h5888daf_1005
-  - gfortran_impl_linux-64=15.2.0=h281d09f_19
-  - ghostscript=10.07.1=hecca717_0
-  - giddy=2.3.8=pyhd8ed1ab_0
-  - giflib=5.2.2=hd590300_0
-  - gitdb=4.0.12=pyhd8ed1ab_0
-  - gitpython=3.1.50=pyhd8ed1ab_0
-  - gl2ps=1.4.2=h36e74d4_2
-  - glcontext=3.0.0=py312h1289d80_3
-  - glew=2.1.0=h9c3ff4c_2
-  - glib=2.84.0=h07242d1_0
-  - glib-tools=2.84.0=h4833e2c_0
-  - globus-sdk=3.65.0=pyhd8ed1ab_0
-  - glog=0.7.1=hbabe93e_0
-  - gmp=6.3.0=hac33072_2
-  - gmpy2=2.3.0=py312hcaba1f9_1
-  - gmt=6.5.0=h4b96b86_7
-  - google-api-core=2.30.3=pyhcf101f3_0
-  - google-auth=2.55.1=pyhcf101f3_0
-  - google-auth-oauthlib=1.4.0=pyhd8ed1ab_0
-  - google-cloud-core=2.5.0=pyhcf101f3_1
-  - google-cloud-storage=3.12.0=pyhcf101f3_0
-  - google-cloud-storage-control=1.10.0=pyhcf101f3_0
-  - google-crc32c=1.8.0=py312h03f33d3_1
-  - google-pasta=0.2.0=pyhd8ed1ab_2
-  - google-resumable-media=2.8.0=pyhd8ed1ab_0
-  - googleapis-common-protos=1.75.0=pyhcf101f3_0
-  - googleapis-common-protos-grpc=1.75.0=pyhcf101f3_0
-  - graphite2=1.3.15=hecca717_0
-  - graphviz=12.2.1=h5ae0cbf_1
-  - greenlet=3.5.3=py312h8285ef7_0
-  - gridfill=1.1.1=py312h4f23490_4
-  - grpc-google-iam-v1=0.14.4=pyhcf101f3_0
-  - grpcio=1.67.1=py312hacea422_2
-  - grpcio-status=1.67.1=pyhd8ed1ab_1
-  - gshhg-gmt=2.3.7=ha770c72_1003
-  - gsl=2.7=he838d99_0
-  - gst-plugins-base=1.24.7=h0a52356_0
-  - gstreamer=1.24.7=hf3bb09a_0
-  - gsw=3.6.23=h7c397b8_0
-  - gtk3=3.24.43=h0c6a113_5
-  - gts=0.7.6=h977cf35_4
-  - gxx_impl_linux-64=15.2.0=hda75c37_19
-  - h11=0.16.0=pyhcf101f3_1
-  - h2=4.3.0=pyhcf101f3_0
-  - h3=4.3.0=h3e4d06c_1
-  - h3-py=4.3.0=py312h8285ef7_3
-  - h5netcdf=1.8.1=pyhd8ed1ab_0
-  - h5py=3.13.0=nompi_py312hedeef09_100
-  - harfbuzz=11.0.0=h76408a6_0
-  - hdbscan=0.8.44=py312h4f23490_0
-  - hdf4=4.2.15=h2a13503_7
-  - hdf5=1.14.3=mpi_openmpi_h39ae36c_9
-  - hdfeos2=2.20=h3e53b52_1004
-  - hdfeos5=5.1.16=h51d0b48_17
-  - hf-xet=1.5.1=py310hb823017_0
-  - hicolor-icon-theme=0.17=ha770c72_3
-  - highspy=1.14.0=np2py312h0f77346_0
-  - holidays=0.99=pyhcf101f3_0
-  - holoviews=1.23.1=pyhd8ed1ab_0
-  - hpack=4.2.0=pyhd8ed1ab_0
-  - html5lib=1.1=pyhd8ed1ab_2
-  - httpcore=1.0.9=pyh29332c3_0
-  - httpx=0.28.1=pyhd8ed1ab_0
-  - huggingface_hub=1.22.0=pyhcf101f3_0
-  - humanfriendly=10.0=pyh707e725_8
-  - hupper=1.12.1=pyhd8ed1ab_1
-  - hvplot=0.12.2=pyhd8ed1ab_0
-  - hyperframe=6.1.0=pyhd8ed1ab_0
-  - icclim=7.1.1=pyhd8ed1ab_0
-  - icechunk=2.1.0=py312h0ccc70a_0
-  - icu=75.1=he02047a_0
-  - id=1.6.1=pyhcf101f3_0
-  - identify=2.6.19=pyhd8ed1ab_0
-  - idna=3.18=pyhcf101f3_0
-  - ilamb=2.7.3=py312h7900ff3_0
-  - imagecodecs=2025.3.30=py312hbc2ce58_0
-  - imagehash=4.3.2=pyhd8ed1ab_0
-  - imageio=2.37.0=pyhfb79c49_0
-  - imagemagick=7.1.1_47=imagemagick_hf2058d9_0
-  - imagesize=2.0.0=pyhd8ed1ab_0
-  - imath=3.1.12=h7955e40_0
-  - immutabledict=4.3.1=pyhd8ed1ab_0
-  - importlib-metadata=9.0.0=pyhcf101f3_0
-  - importlib-resources=7.1.0=pyhd8ed1ab_0
-  - importlib_resources=7.1.0=pyhd8ed1ab_0
-  - inequality=1.1.2=pyhd8ed1ab_1
-  - iniconfig=2.3.0=pyhd8ed1ab_0
-  - intake=2.0.8=pyhd8ed1ab_0
-  - intake-dataframe-catalog=0.5.1=pyhd8ed1ab_0
-  - intake-esgf=2026.6.4=pyhd8ed1ab_0
-  - intake-esm=2025.12.12=pyhd8ed1ab_0
-  - intake-esm-access=2026.4.15=py_0
-  - intake-virtual-icechunk=0.2.2=py_0
-  - ipdb=0.13.13=pyhd8ed1ab_1
-  - ipydatagrid=1.4.0=pyhcf101f3_2
-  - ipykernel=6.31.0=pyha191276_0
-  - ipympl=0.10.0=pyhcf101f3_0
-  - ipynbname=2023.2.0.0=pyhd8ed1ab_0
-  - ipython=9.15.0=pyh53cf698_0
-  - ipython_pygments_lexers=1.1.1=pyhd8ed1ab_0
-  - ipywidgets=8.1.8=pyhd8ed1ab_0
-  - iris=3.14.1=pyha770c72_0
-  - iris-esmf-regrid=0.15.0=pyhd8ed1ab_1
-  - iris-grib=0.22.0=pyhd8ed1ab_0
-  - iso8601=2.1.0=pyhd8ed1ab_1
-  - isodate=0.7.2=pyhd8ed1ab_1
-  - isoduration=20.11.0=pyhd8ed1ab_1
-  - isort=5.13.2=pyhd8ed1ab_1
-  - itables=2.8.1=pyhb6928c1_0
-  - itsdangerous=2.2.0=pyhd8ed1ab_1
-  - jags=4.3.2=h647a790_1
-  - jaraco.classes=3.4.0=pyhcf101f3_3
-  - jaraco.context=6.1.2=pyhcf101f3_0
-  - jaraco.functools=4.5.0=pyhcf101f3_0
-  - jasper=4.2.9=h1588d4d_1
-  - jbig=2.1=h7f98852_2003
-  - jedi=0.20.0=pyhcf101f3_0
-  - jeepney=0.9.0=pyhd8ed1ab_0
-  - jinja2=3.1.6=pyhcf101f3_1
-  - jmespath=1.1.0=pyhcf101f3_1
-  - joblib=1.5.3=pyhd8ed1ab_0
-  - jplephem=2.24=pyha4b2019_1
-  - jq=1.8.2=h280c20c_0
-  - jsmin=3.0.1=pyhd8ed1ab_1
-  - json-c=0.18=h6688a6e_0
-  - json5=0.15.0=pyhd8ed1ab_0
-  - jsoncpp=1.9.6=hf42df4d_1
-  - jsonpatch=1.33=pyhd8ed1ab_1
-  - jsonpickle=4.1.2=pyhcf101f3_0
-  - jsonpointer=3.1.1=pyhcf101f3_0
-  - jsonschema=4.26.0=pyhcf101f3_0
-  - jsonschema-specifications=2025.9.1=pyhcf101f3_0
-  - jsonschema-with-format-nongpl=4.26.0=hcf101f3_0
-  - jupyter=1.1.1=pyhd8ed1ab_1
-  - jupyter-book=2.1.5=pyhcf101f3_0
-  - jupyter-lsp=2.3.1=pyhcf101f3_0
-  - jupyter-resource-usage=1.2.1=pyhd8ed1ab_0
-  - jupyter-server-proxy=4.5.0=pyhcf101f3_1
-  - jupyter_bokeh=4.1.0=pyhcf101f3_0
-  - jupyter_client=8.9.1=pyhcf101f3_0
-  - jupyter_console=6.6.3=pyhd8ed1ab_1
-  - jupyter_core=5.9.1=pyhc90fa1f_0
-  - jupyter_events=0.12.1=pyhcf101f3_0
-  - jupyter_server=2.20.0=pyhcf101f3_0
-  - jupyter_server_terminals=0.5.4=pyhcf101f3_0
-  - jupyterlab=4.5.0=pyhd8ed1ab_0
-  - jupyterlab_pygments=0.3.0=pyhd8ed1ab_2
-  - jupyterlab_server=2.28.0=pyhcf101f3_0
-  - jupyterlab_widgets=3.0.16=pyhcf101f3_1
-  - jxrlib=1.1=hd590300_3
-  - kealib=1.6.1=he902fbf_0
-  - keras=3.11.2=pyh753f3f9_0
-  - kerchunk=0.2.10=pyhd8ed1ab_0
-  - kernel-headers_linux-64=4.18.0=he073ed8_9
-  - keyring=25.7.0=pyha804496_0
-  - keystoneauth1=5.15.0=pyhd8ed1ab_0
-  - keyutils=1.6.3=hb9d3cd8_0
-  - kiwisolver=1.5.0=py312h0a2e395_0
-  - knem-headers=1.1.4=ha770c72_2
-  - krb5=1.21.3=h659f571_0
-  - lame=3.100=h166bdaf_1003
-  - lark=1.3.1=pyhd8ed1ab_0
-  - lat_lon_parser=1.3.1=pyhd8ed1ab_1
-  - latexcodec=2.0.1=pyh9f0ad1d_0
-  - lazy-loader=0.5=pyhd8ed1ab_0
-  - lazy_loader=0.5=pyhd8ed1ab_0
-  - lcms2=2.19.1=h0c24ade_1
-  - ld_impl_linux-64=2.45.1=default_hbd61a6d_102
-  - legacy-cgi=2.6.4=pyhcf101f3_0
-  - lerc=4.1.0=hdb68285_0
-  - level-zero=1.29.0=hb700be7_0
-  - lftp=4.9.3=h81d5518_2
-  - libabseil=20240722.0=cxx17_hbbce691_4
-  - libaec=1.1.5=h088129d_0
-  - libarchive=3.7.7=h75ea233_4
-  - libarrow=19.0.1=hc7b3859_3_cpu
-  - libarrow-acero=19.0.1=hcb10f89_3_cpu
-  - libarrow-dataset=19.0.1=hcb10f89_3_cpu
-  - libarrow-substrait=19.0.1=h08228c5_3_cpu
-  - libasprintf=0.25.1=h3f43e3d_1
-  - libasprintf-devel=0.25.1=h3f43e3d_1
-  - libass=0.17.3=h52826cd_2
-  - libavif16=1.3.0=h766b0b6_0
-  - libblas=3.9.0=20_linux64_mkl
-  - libboost=1.90.0=hed09d94_0
-  - libbrotlicommon=1.1.0=hb03c661_4
-  - libbrotlidec=1.1.0=hb03c661_4
-  - libbrotlienc=1.1.0=hb03c661_4
-  - libcap=2.78=hd0affe5_0
-  - libcblas=3.9.0=20_linux64_mkl
-  - libcbor=0.10.2=hcb278e6_0
-  - libclang-cpp20.1=20.1.8=default_h99862b1_16
-  - libclang13=21.1.0=default_h746c552_1
-  - libcrc32c=1.1.2=h9c3ff4c_0
-  - libcst=1.8.6=py312h121d7ae_1
-  - libcublas=12.4.5.8=he02047a_2
-  - libcufft=11.2.1.3=he02047a_2
-  - libcufile=1.9.1.3=he02047a_2
-  - libcups=2.3.3=hb8b1518_5
-  - libcurand=10.3.5.147=he02047a_2
-  - libcurl=8.18.0=h4e3cde8_0
-  - libcusolver=11.6.1.9=he02047a_2
-  - libcusparse=12.3.1.170=he02047a_2
-  - libde265=1.0.15=h00ab1b0_0
-  - libdeflate=1.25=h17f619e_0
-  - libdrm=2.4.127=hb03c661_0
-  - libedit=3.1.20250104=pl5321h7949ede_0
-  - libegl=1.7.0=ha4b6fd6_3
-  - libegl-devel=1.7.0=ha4b6fd6_3
-  - libev=4.33=hd590300_2
-  - libevent=2.1.12=hf998b51_1
-  - libexpat=2.8.1=hecca717_1
-  - libfabric=2.6.0=ha770c72_0
-  - libfabric1=2.6.0=h6b3ec72_0
-  - libffi=3.5.2=h3435931_0
-  - libfido2=1.17.0=h8c08ba8_0
-  - libflac=1.5.0=he200343_1
-  - libfreetype=2.14.3=ha770c72_0
-  - libfreetype6=2.14.3=h73754d4_0
-  - libgcc=15.2.0=he0feb66_19
-  - libgcc-devel_linux-64=15.2.0=hcc6f6b0_119
-  - libgcc-ng=15.2.0=h69a702a_19
-  - libgd=2.3.3=h6f5c62b_11
-  - libgdal=3.10.2=hea5fcb0_5
-  - libgdal-core=3.10.2=h3359108_0
-  - libgdal-fits=3.10.2=h872822d_0
-  - libgdal-grib=3.10.2=h724c1be_0
-  - libgdal-hdf4=3.10.2=h05c48c5_0
-  - libgdal-hdf5=3.10.2=hf0b1780_0
-  - libgdal-jp2openjpeg=3.10.2=ha1d2769_0
-  - libgdal-kea=3.10.2=h41c5bbd_0
-  - libgdal-netcdf=3.10.2=ha1d9371_0
-  - libgdal-pdf=3.10.2=h8221dc3_0
-  - libgdal-pg=3.10.2=ha83508c_0
-  - libgdal-postgisraster=3.10.2=ha83508c_0
-  - libgdal-tiledb=3.10.2=h30425e6_0
-  - libgdal-xls=3.10.2=h5b36e33_0
-  - libgettextpo=0.25.1=h3f43e3d_1
-  - libgettextpo-devel=0.25.1=h3f43e3d_1
-  - libgfortran=15.2.0=h69a702a_19
-  - libgfortran-ng=15.2.0=h69a702a_19
-  - libgfortran5=15.2.0=h68bc16d_19
-  - libgit2=1.9.0=h502187d_1
-  - libgl=1.7.0=ha4b6fd6_3
-  - libgl-devel=1.7.0=ha4b6fd6_3
-  - libglib=2.84.0=h2ff4ddf_0
-  - libglu=9.0.3=h5888daf_1
-  - libglvnd=1.7.0=ha4b6fd6_3
-  - libglx=1.7.0=ha4b6fd6_3
-  - libglx-devel=1.7.0=ha4b6fd6_3
-  - libgomp=15.2.0=he0feb66_19
-  - libgoogle-cloud=2.36.0=h2b5623c_0
-  - libgoogle-cloud-storage=2.36.0=h0121fbd_0
-  - libgrpc=1.67.1=h25350d4_2
-  - libheif=1.19.7=gpl_hc18d805_100
-  - libhwloc=2.12.1=default_h3d81e11_1000
-  - libhwy=1.3.0=h4c17acf_1
-  - libiconv=1.18=h3b78370_2
-  - libjpeg-turbo=3.1.4.1=hb03c661_0
-  - libjxl=0.11.1=h6cb5226_4
-  - libkml=1.3.0=haa4a5bd_1023
-  - liblapack=3.9.0=20_linux64_mkl
-  - liblapacke=3.9.0=20_linux64_mkl
-  - liblief=0.17.6=hecca717_0
-  - liblightgbm=4.6.0=cpu_hf025404_8
-  - libllvm20=20.1.8=hecd9e04_0
-  - libllvm21=21.1.0=hecd9e04_0
-  - liblzma=5.8.3=hb03c661_0
-  - liblzma-devel=5.8.3=hb03c661_0
-  - libmagic=5.48=h421ea60_1
-  - libmamba=2.0.8=hf3fef5c_0
-  - libmambapy=2.0.8=py312h1d7e3b0_0
-  - libml_dtypes-headers=0.5.4=h707e725_0
-  - libmo_unpack=3.1.2=hf484d3e_1001
-  - libnetcdf=4.9.2=mpi_openmpi_ha1e512f_14
-  - libnghttp2=1.68.1=h877daf1_0
-  - libnl=3.11.0=hb9d3cd8_0
-  - libnpp=12.2.5.30=he02047a_2
-  - libnsl=2.0.1=hb9d3cd8_1
-  - libntlm=1.8=hb9d3cd8_0
-  - libnvfatbin=12.4.127=he02047a_2
-  - libnvjitlink=12.4.127=he02047a_2
-  - libnvjpeg=12.3.1.117=he02047a_2
-  - libogg=1.3.5=hd0c01bc_1
-  - libopenblas=0.3.33=pthreads_h94d23a6_0
-  - libopencv=4.11.0=qt6_py312h8ec186b_602
-  - libopengl=1.7.0=ha4b6fd6_3
-  - libopentelemetry-cpp=1.18.0=hfcad708_1
-  - libopentelemetry-cpp-headers=1.18.0=ha770c72_1
-  - libopenvino=2025.0.0=hdc3f47d_2
-  - libopenvino-auto-batch-plugin=2025.0.0=h4d9b6c2_2
-  - libopenvino-auto-plugin=2025.0.0=h4d9b6c2_2
-  - libopenvino-hetero-plugin=2025.0.0=h981d57b_2
-  - libopenvino-intel-cpu-plugin=2025.0.0=hdc3f47d_2
-  - libopenvino-intel-gpu-plugin=2025.0.0=hdc3f47d_2
-  - libopenvino-intel-npu-plugin=2025.0.0=hdc3f47d_2
-  - libopenvino-ir-frontend=2025.0.0=h981d57b_2
-  - libopenvino-onnx-frontend=2025.0.0=h6363af5_2
-  - libopenvino-paddle-frontend=2025.0.0=h6363af5_2
-  - libopenvino-pytorch-frontend=2025.0.0=h5888daf_2
-  - libopenvino-tensorflow-frontend=2025.0.0=h630ec5c_2
-  - libopenvino-tensorflow-lite-frontend=2025.0.0=h5888daf_2
-  - libopus=1.6.1=h280c20c_0
-  - libosqp=1.0.0=np2py312h1a77e3e_2
-  - libparquet=19.0.1=h081d1f1_3_cpu
-  - libpciaccess=0.19=hb03c661_0
-  - libpmix=5.0.8=h4bd6b51_2
-  - libpnetcdf=1.13.0=mpi_openmpi_h521bef2_1
-  - libpng=1.6.58=h421ea60_0
-  - libpq=17.6=h3675c94_1
-  - libprotobuf=5.28.3=h6128344_1
-  - libpysal=4.14.1=pyhd8ed1ab_0
-  - libqdldl=0.1.8=h3f2d84a_1
-  - libre2-11=2024.07.02=hbbce691_2
-  - librsvg=2.58.4=he92a37e_3
-  - librttopo=1.1.0=h97f6797_17
-  - libsanitizer=15.2.0=h90f66d4_19
-  - libsndfile=1.2.2=hc7d488a_2
-  - libsodium=1.0.20=h4ab18f5_0
-  - libsolv=0.7.30=h3509ff9_0
-  - libspatialindex=2.1.0=h54a6638_1
-  - libspatialite=5.1.0=h1b4f908_12
-  - libsqlite=3.53.3=h0c1763c_0
-  - libssh2=1.11.1=hcf80075_0
-  - libstdcxx=15.2.0=h934c35e_19
-  - libstdcxx-devel_linux-64=15.2.0=hd446a21_119
-  - libstdcxx-ng=15.2.0=hdf11a46_19
-  - libsystemd0=257.13=h084b8d7_1
-  - libtensorflow_cc=2.18.0=cpu_h739b781_2
-  - libtensorflow_framework=2.18.0=cpu_h417b707_2
-  - libtheora=1.1.1=h4ab18f5_1006
-  - libthrift=0.21.0=h0e7cc3e_0
-  - libtiff=4.7.2=h9d88235_0
-  - libudev1=257.13=h084b8d7_1
-  - libudunits2=2.2.28=h40f5838_3
-  - libunwind=1.6.2=h9c3ff4c_0
-  - liburing=2.9=h84d6215_0
-  - libusb=1.0.29=h73b1eb8_0
-  - libutf8proc=2.10.0=h202a827_0
-  - libuuid=2.42.2=h5347b49_0
-  - libuv=1.52.1=h280c20c_0
-  - libva=2.24.0=he1eb515_0
-  - libvorbis=1.3.7=h54a6638_2
-  - libvpx=1.14.1=hac33072_0
-  - libwebp=1.6.0=h9635ea4_0
-  - libwebp-base=1.6.0=hd42ef1d_0
-  - libxcb=1.17.0=h8a09558_0
-  - libxcrypt=4.4.36=hd590300_1
-  - libxgboost=3.3.0=cpu_h2ebb00f_0
-  - libxkbcommon=1.11.0=he8b52b9_0
-  - libxml2=2.13.9=h04c0eec_0
-  - libxslt=1.1.43=h7a3aeb2_0
-  - libzip=1.11.2=h6991a6a_0
-  - libzlib=1.3.2=h25fd6f3_2
-  - libzopfli=1.0.3=h9c3ff4c_0
-  - lightgbm=4.6.0=cpu_py_hb6b7976_8
-  - lightning-utilities=0.15.3=pyhd8ed1ab_0
-  - lime=0.2.0.1=pyhd8ed1ab_2
-  - line_profiler=5.0.2=py312h0a2e395_0
-  - linkify-it-py=2.1.0=pyhcf101f3_0
-  - llvm-openmp=15.0.7=h0cdce71_0
-  - llvmlite=0.47.0=py312h7424e68_1
-  - lmfit=1.3.4=pyhd8ed1ab_0
-  - lmoments3=1.0.8=pyhd8ed1ab_1
-  - locket=1.0.0=pyhd8ed1ab_0
-  - logilab-common=1.7.3=py_0
-  - loguru=0.7.3=pyh707e725_0
-  - lxml=6.0.2=py312h70dad80_0
-  - lz4=4.4.5=py312h3d67a73_1
-  - lz4-c=1.10.0=h5888daf_1
-  - lzo=2.10=h280c20c_1002
-  - magics=4.15.5=hc87abea_0
-  - magics-python=1.5.8=pyhd8ed1ab_1
-  - make=4.4.1=hb9d3cd8_2
-  - mako=1.3.12=pyhcf101f3_0
-  - mamba=2.0.8=h3f3603c_0
-  - mapclassify=2.10.0=pyhd8ed1ab_1
-  - mapgenerator=1.0.7=pyhd8ed1ab_0
-  - markdown=3.10.2=pyhcf101f3_0
-  - markdown-it-py=4.2.0=pyhd8ed1ab_0
-  - markupsafe=3.0.3=py312h8a5da7c_1
-  - marshmallow=3.26.2=pyhd8ed1ab_0
-  - matchpy=0.5.5=pyhd8ed1ab_0
-  - matplotlib=3.10.9=py312h7900ff3_0
-  - matplotlib-base=3.10.9=py312he3d6523_0
-  - matplotlib-inline=0.2.2=pyhd8ed1ab_0
-  - matplotlib-scalebar=0.9.0=pyhd8ed1ab_0
-  - matplotlib-venn=1.1.2=pyhd8ed1ab_0
-  - mayavi=4.8.2=pyqt_py312h040c957_309
-  - mbedtls=3.6.3.1=h5888daf_0
-  - mccabe=0.7.0=pyhd8ed1ab_1
-  - mda-xdrlib=0.2.0=pyhd8ed1ab_1
-  - mdit-py-plugins=0.6.1=pyhd8ed1ab_0
-  - mdurl=0.1.2=pyhd8ed1ab_1
-  - memory_profiler=0.61.0=pyhcf101f3_1
-  - menuinst=2.5.1=py312h20c3967_0
-  - mercantile=1.2.1=pyhd8ed1ab_1
-  - metpy=1.7.1=pyhd8ed1ab_0
-  - mgwr=2.2.1=pyhd8ed1ab_1
-  - minizip=4.2.2=hb71707f_0
-  - mistune=3.3.2=pyhcf101f3_0
-  - mkl=2023.2.0=ha770c72_50498
-  - ml_dtypes=0.4.0=py312hf9745cd_2
-  - mmh3=5.2.1=py312h1289d80_0
-  - mo_pack=0.3.1=py312h4f23490_2
-  - moderngl=5.12.0=py312hf79963d_0
-  - momepy=1.0.0=pyhd8ed1ab_0
-  - more-itertools=11.1.0=pyhcf101f3_0
-  - morphys=1.0=pyhd8ed1ab_0
-  - mpc=1.4.0=he0a73b1_0
-  - mpfr=4.2.2=he0a73b1_0
-  - mpg123=1.32.9=hc50e24c_0
-  - mpi=1.0=openmpi
-  - mpi4py=4.1.2=py312hd140a38_100
-  - mpl-scatter-density=0.8=pyhd8ed1ab_1
-  - mplleaflet=0.0.5=pyhd8ed1ab_5
-  - mplotutils=0.6.0=pyhd8ed1ab_0
-  - mpmath=1.4.1=pyhd8ed1ab_0
-  - mscorefonts=0.0.1=3
-  - msgpack-python=1.2.1=py312h0a2e395_1
-  - multidict=6.7.1=py312h8a5da7c_0
-  - multipledispatch=0.6.0=pyhd8ed1ab_1
-  - multiset=2.1.1=py_0
-  - multiurl=0.3.9=pyhd8ed1ab_0
-  - munkres=1.1.4=pyhd8ed1ab_1
-  - myproxyclient=2.2.0=pyhd8ed1ab_0
-  - mypy_extensions=1.1.0=pyha770c72_0
-  - mysql-common=9.0.1=h266115a_6
-  - mysql-libs=9.0.1=he0572af_6
-  - namex=0.1.0=pyhd8ed1ab_0
-  - narwhals=2.23.0=pyhcf101f3_0
-  - natsort=8.4.0=pyhcf101f3_2
-  - nb_conda_kernels=2.5.1=pyh707e725_2
-  - nbclient=0.11.0=pyhd8ed1ab_0
-  - nbconvert=7.17.1=hb502eef_0
-  - nbconvert-core=7.17.1=pyhcf101f3_0
-  - nbconvert-pandoc=7.17.1=h08b4883_0
-  - nbdime=4.0.4=pyhcf101f3_0
-  - nbformat=5.10.4=pyhd8ed1ab_1
-  - nbsphinx=0.9.8=pyhd8ed1ab_0
-  - nbval=0.11.0=pyhd8ed1ab_1
-  - nc-time-axis=1.4.1=pyhd8ed1ab_1
-  - ncdata=0.3.2=pyhd8ed1ab_1
-  - ncdu=1.22=h18c060e_0
-  - ncl=6.6.2=ha9e1b40_55
-  - nco=5.3.3=h657489c_0
-  - ncplot=0.3.10=py312he8689d4_4
-  - nctoolkit=1.3.0=py312h7900ff3_0
-  - ncurses=6.6=hdb14827_0
-  - nest-asyncio=1.6.0=pyhd8ed1ab_1
-  - nested-lookup=0.2.25=pyhd8ed1ab_2
-  - netaddr=1.3.0=pyhcf101f3_2
-  - netcdf-fortran=4.6.1=mpi_openmpi_h2e02aee_8
-  - netcdf4=1.7.2=nompi_py312h21d6d8e_101
-  - networkx=3.6.1=pyhcf101f3_0
-  - neutralocean=2.4.1=pyhd8ed1ab_0
-  - nfoursid=1.0.2=pyhd8ed1ab_0
-  - nh3=0.3.6=py310hd8a072f_0
-  - ninja=1.13.2=h171cf75_0
-  - nlohmann_json=3.11.3=he02047a_1
-  - nodeenv=1.10.0=pyhd8ed1ab_0
-  - nodejs=24.10.0=h8c692ec_1
-  - notebook=7.5.0=pyhcf101f3_0
-  - notebook-shim=0.2.4=pyhd8ed1ab_1
-  - nspr=4.38=h29cc59b_0
-  - nss=3.118=h445c969_0
-  - numba=0.65.1=py312hd1dde6f_1
-  - numcodecs=0.16.5=py312hf79963d_0
-  - numexpr=2.10.1=mkl_py312h791fadb_2
-  - numpy=2.4.6=py312h33ff503_0
-  - numpy_groupies=0.11.3=pyhd8ed1ab_0
-  - nvidia-ml-py=12.575.51=pyhd8ed1ab_0
-  - oauthlib=3.3.1=pyhd8ed1ab_0
-  - obspec=0.1.0=pyhd8ed1ab_0
-  - obspec_utils=0.9.0=pyhd8ed1ab_0
-  - obstore=0.11.0=py312h0ccc70a_0
-  - ocl-icd=2.3.4=hb03c661_1
-  - odc-geo=0.5.1=pyhd8ed1ab_0
-  - oniguruma=6.9.10=hb9d3cd8_0
-  - open-radar-data=0.8.0=pyhd8ed1ab_0
-  - openblas=0.3.33=pthreads_h6ec200e_0
-  - opencl-headers=2025.06.13=hecca717_0
-  - opencv=4.11.0=qt6_py312h56813e9_602
-  - openexr=3.3.5=h09fa569_0
-  - openh264=2.6.0=h65dd3cf_1
-  - openjpeg=2.5.4=h55fea9a_0
-  - openldap=2.6.10=he970967_0
-  - openmpi=5.0.8=hacb30cd_104
-  - openpyxl=3.1.5=py312h7f6eeab_3
-  - openssh=10.2p1=h20e8eec_0
-  - openssl=3.6.3=h35e630c_0
-  - openstacksdk=4.17.0=pyhd8ed1ab_0
-  - opt_einsum=3.4.0=pyhd8ed1ab_1
-  - optree=0.19.1=py312hd9148b4_0
-  - orc=2.1.1=h2271f48_0
-  - os-service-types=1.8.2=pyhd8ed1ab_0
-  - osc-lib=4.6.0=pyhd8ed1ab_0
-  - oslo.config=10.5.0=pyhd8ed1ab_0
-  - oslo.i18n=6.8.0=pyhd8ed1ab_0
-  - oslo.serialization=5.10.0=pyhd8ed1ab_0
-  - oslo.utils=10.1.1=pyhd8ed1ab_0
-  - osqp=1.1.3=np2py312h0f77346_0
-  - overrides=7.7.0=pyhd8ed1ab_1
-  - owslib=0.36.0=pyhc364b38_0
-  - packaging=26.2=pyhc364b38_0
-  - palettable=3.3.3=pyhd8ed1ab_1
-  - pandas=2.3.3=py312hf79963d_1
-  - pandoc=3.10=ha770c72_0
-  - pandocfilters=1.5.0=pyhd8ed1ab_0
-  - panel=1.9.3=pyhd8ed1ab_0
-  - panel-core=1.9.3=pyha770c72_0
-  - panel-material-ui=0.13.0=pyhd8ed1ab_0
-  - pango=1.56.3=h9ac818e_1
-  - papermill=2.7.0=pyhd8ed1ab_0
-  - parallelio=2.6.3=mpi_openmpi_h9c32635_0
-  - param=2.4.1=pyhc455866_0
-  - parcels=3.1.0=pyh6fe113f_1
-  - parsl=2026.6.29=pyhcf101f3_0
-  - parso=0.8.7=pyhcf101f3_0
-  - partd=1.4.2=pyhd8ed1ab_0
-  - patch=2.8=hb03c661_1002
-  - patchelf=0.17.2=h58526e2_0
-  - pathlib-abc=0.5.2=pyh9692d8f_0
-  - pathspec=1.1.1=pyhd8ed1ab_0
-  - patsy=1.0.2=pyhcf101f3_0
-  - pbr=7.0.3=pyhd8ed1ab_0
-  - pcre=8.45=h9c3ff4c_0
-  - pcre2=10.44=hc749103_2
-  - pdbufr=0.14.2=pyhcf101f3_0
-  - pendulum=3.2.0=py312h868fb18_2
-  - pep8-naming=0.10.0=pyh9f0ad1d_0
-  - pexpect=4.9.0=pyhd8ed1ab_1
-  - pillow=12.0.0=py312h898c6c0_1
-  - pint=0.25.3=pyhc364b38_0
-  - pint-xarray=0.6.1=pyhd8ed1ab_0
-  - pip=26.1.2=pyh8b19718_0
-  - pixman=0.46.4=h54a6638_1
-  - pkg-config=0.29.2=h4bc722e_1009
-  - pkginfo=1.12.1.2=pyhd8ed1ab_0
-  - platformdirs=4.10.0=pyhcf101f3_0
-  - plotly=6.8.0=pyhd8ed1ab_0
-  - pluggy=1.6.0=pyhf9edf01_1
-  - ply=3.11=pyhd8ed1ab_3
-  - pointpats=2.5.2=pyhd8ed1ab_0
-  - polars=1.32.3=default_h3512890_0
-  - polars-default=1.32.3=py39hf521cc8_0
-  - pooch=1.9.0=pyhd8ed1ab_0
-  - poppler=24.12.0=hd7b24de_2
-  - poppler-data=0.4.12=hd8ed1ab_0
-  - posix_ipc=1.3.2=py312h4c3975b_0
-  - postgresql=17.6=h021f68a_1
-  - pre-commit=4.6.0=pyha770c72_0
-  - prettytable=3.18.0=pyhd8ed1ab_0
-  - progressbar2=4.5.0=pyhd8ed1ab_1
-  - proj=9.5.1=h0054346_0
-  - prometheus-cpp=1.3.0=ha5d0236_0
-  - prometheus_client=0.25.0=pyhd8ed1ab_0
-  - prompt-toolkit=3.0.52=pyha770c72_0
-  - prompt_toolkit=3.0.52=hd8ed1ab_0
-  - propcache=0.5.2=py312h8a5da7c_0
-  - properscoring=0.1=pyhd8ed1ab_1
-  - prospector=1.19.0=pyhd8ed1ab_0
-  - proto-plus=1.28.0=pyhcf101f3_0
-  - protobuf=5.28.3=py312h2ec8cdc_0
-  - prov=2.0.0=pyhd3deb0d_0
-  - psutil=7.2.2=py312h5253ce2_0
-  - pthread-stubs=0.4=hb9d3cd8_1002
-  - ptyprocess=0.7.0=pyhd8ed1ab_1
-  - pugixml=1.15=h3f63f65_0
-  - pulp=2.8.0=py312hd0750ca_3
-  - pulseaudio-client=17.0=hac146a9_1
-  - pure_eval=0.2.3=pyhd8ed1ab_1
-  - py-cordex=0.10.5=pyhd8ed1ab_0
-  - py-cpuinfo=9.0.0=pyhd8ed1ab_1
-  - py-lief=0.17.6=py312h1289d80_0
-  - py-multihash=3.0.0=pyhd8ed1ab_0
-  - py-opencv=4.11.0=qt6_py312hf68ab4e_602
-  - py-rattler=0.25.0=py310h70157a2_1
-  - py-rattler-build=0.67.0=py310hb823017_0
-  - py-xgboost=3.3.0=cpu_pyh718b53a_0
-  - py2vega=0.7.0=pyhd8ed1ab_0
-  - pyaml=26.2.1=pyhcf101f3_1
-  - pyarrow=19.0.1=py312h7900ff3_2
-  - pyarrow-core=19.0.1=py312hc195796_2_cpu
-  - pyasn1=0.6.3=pyhcf101f3_0
-  - pyasn1-modules=0.4.2=pyhd8ed1ab_0
-  - pybind11-abi=4=hd8ed1ab_3
-  - pybtex=0.26.1=pyhcf101f3_0
-  - pycodestyle=2.14.0=pyhd8ed1ab_0
-  - pycosat=0.6.6=py312h4c3975b_3
-  - pycparser=3.0=pyhcf101f3_0
-  - pyct=0.6.0=pyhd8ed1ab_0
-  - pydantic=2.13.4=pyhcf101f3_0
-  - pydantic-core=2.46.4=py312h868fb18_0
-  - pydap=3.5.10=pyhc455866_0
-  - pydata-sphinx-theme=0.19.0=pyhcf101f3_0
-  - pydocstyle=6.3.0=pyhd8ed1ab_1
-  - pydot=4.0.1=pyhcf101f3_2
-  - pyerfa=2.0.1.5=py310h32771cd_2
-  - pyextremes=2.5.0=pyhd8ed1ab_0
-  - pyface=8.0.0=pyhd8ed1ab_2
-  - pyfive=1.1.2=pyhd8ed1ab_0
-  - pyflakes=3.4.0=pyhd8ed1ab_0
-  - pygam=0.12.0=pyhd8ed1ab_0
-  - pygamma_n=1.0.0=py312h4cfd3ad_1
-  - pygeoif=1.6.0=pyhd8ed1ab_0
-  - pygments=2.20.0=pyhd8ed1ab_0
-  - pygmt=0.18.0=pyhcf101f3_0
-  - pygrib=2.1.8=py312h2f48d4f_0
-  - pyhdf=0.11.6=py312h52fbf50_2
-  - pyjwt=2.13.0=pyhcf101f3_0
-  - pykdtree=1.4.3=py312h4f23490_2
-  - pylint=4.0.6=pyhcf101f3_0
-  - pylint-celery=0.3=py_1
-  - pylint-django=2.7.0=pyhd8ed1ab_0
-  - pylint-flask=0.6=py_0
-  - pylint-plugin-utils=0.9.0=pyhd8ed1ab_0
-  - pymannkendall=1.4.3=pyha21a80b_0
-  - pymbolic=2025.1=pyhc455866_0
-  - pynvml=12.0.0=pyhd8ed1ab_0
-  - pyod=3.6.1=pyhd8ed1ab_0
-  - pyogrio=0.10.0=py312h02b19dd_1
-  - pyopenssl=26.3.0=pyhcf101f3_0
-  - pyorbital=1.12.1=pyhd8ed1ab_0
-  - pyparsing=3.3.2=pyhcf101f3_0
-  - pyperclip=1.11.0=pyha804496_0
-  - pyproj=3.7.1=py312he630544_0
-  - pyproject_hooks=1.2.0=pyhd8ed1ab_1
-  - pyqt=5.15.11=py312h82c0db2_2
-  - pyqt5-sip=12.17.0=py312h1289d80_2
-  - pyresample=1.35.0=py312h1289d80_0
-  - pyroma=5.0.1=pyhd8ed1ab_0
-  - pys2index=0.1.5=py312hbf1ff57_6
-  - pysal=25.7=pyhd8ed1ab_0
-  - pyshp=3.1.4=pyhcf101f3_0
-  - pyside6=6.8.3=py312h91f0f75_0
-  - pysocks=1.7.1=pyha55dd90_7
-  - pyspectral=0.14.3=pyhd8ed1ab_0
-  - pyspharm=1.0.9=np2py312hf70805e_1016
-  - pystac=1.14.3=pyhd8ed1ab_0
-  - pystac-client=0.9.0=pyhd8ed1ab_0
-  - pysteps=1.21.1=py312h4f23490_0
-  - pytables=3.10.2=py312h2895ec7_2
-  - pytest=9.1.1=pyhc364b38_2
-  - pytest-cov=7.1.0=pyhcf101f3_0
-  - pytest-env=1.6.0=pyhd8ed1ab_0
-  - pytest-html=4.2.0=pyhd8ed1ab_0
-  - pytest-metadata=3.1.1=pyhd8ed1ab_1
-  - pytest-mock=3.15.1=pyhd8ed1ab_0
-  - pytest-subtests=0.15.0=pyhd8ed1ab_0
-  - pytest-xdist=3.8.0=pyhd8ed1ab_0
-  - python=3.12.13=hd63d673_0_cpython
-  - python-build=1.5.0=pyhc364b38_0
-  - python-cdo=1.6.1=pyh332efcf_1
-  - python-cinderclient=9.9.0=pyh332efcf_0
-  - python-dateutil=2.9.0.post0=pyhe01879c_2
-  - python-dotenv=1.2.2=pyhcf101f3_0
-  - python-eccodes=2.37.0=py312h4f23490_1
-  - python-fastjsonschema=2.21.2=pyhe01879c_0
-  - python-flatbuffers=25.9.23=pyh1e1bc0e_0
-  - python-geotiepoints=1.9.0=py312h4f23490_1
-  - python-gil=3.12.13=hd8ed1ab_0
-  - python-graphviz=0.21=pyhbacfb6d_0
-  - python-gssapi=1.11.1=py312h7cea900_0
-  - python-installer=1.0.1=pyh332efcf_0
-  - python-json-logger=4.1.0=pyhd8ed1ab_0
-  - python-keystoneclient=5.8.0=pyh332efcf_0
-  - python-libarchive-c=5.3=pyhe01879c_1
-  - python-magic=0.4.27=pyhd7f29a5_7
-  - python-novaclient=18.13.0=pyh332efcf_0
-  - python-openstackclient=9.0.0=pyh332efcf_0
-  - python-stratify=0.4.0=py312h4c3975b_3
-  - python-swiftclient=4.10.0=pyh332efcf_0
-  - python-tzdata=2026.2=pyhd8ed1ab_0
-  - python-utils=4.0.0=pyh332efcf_0
-  - python-xxhash=3.7.0=py312h0d868a3_0
-  - python_abi=3.12=8_cp312
-  - pytokens=0.4.1=py312h5253ce2_2
-  - pytools=2026.1.1=pyhd8ed1ab_0
-  - pytorch=2.5.1=py3.12_cuda12.4_cudnn9.1.0_0
-  - pytorch-cuda=12.4=hc786d27_7
-  - pytorch-lightning=2.5.2=pyh2a12c56_0
-  - pytorch-mutex=1.0=cuda
-  - pytz=2026.2=pyhcf101f3_0
-  - pyu2f=0.1.5=pyhd8ed1ab_1
-  - pyviz_comms=3.0.6=pyhd8ed1ab_0
-  - pywavelets=1.9.0=py312h4f23490_2
-  - pyxdg=0.28=pyhd8ed1ab_0
-  - pyyaml=6.0.3=py312h8a5da7c_1
-  - pyzmq=27.1.0=py312hda471dd_3
-  - qdldl-python=0.1.9.post1=np2py312h0f77346_0
-  - qhull=2020.2=h434a139_5
-  - qt-main=5.15.15=h993ce98_3
-  - qt6-main=6.8.3=h6441bc3_1
-  - quantecon=0.11.2=pyhd8ed1ab_0
-  - quaternion=2024.0.13=py312h4f23490_0
-  - r-abind=1.4_8=r44hc72bb7e_1
-  - r-akima=0.6_3.6=r44heaba542_1
-  - r-backports=1.5.1=r44h54b55ab_0
-  - r-base=4.4.3=h9c32bc2_0
-  - r-bigmemory=4.6.6=r44h3697838_0
-  - r-bigmemory.sri=0.1.8=r44hc72bb7e_2
-  - r-callr=3.7.6=r44hc72bb7e_2
-  - r-checkmate=2.3.3=r44h54b55ab_1
-  - r-class=7.3_23=r44h54b55ab_1
-  - r-classint=0.4_11=r44heaba542_1
-  - r-cli=3.6.6=r44h3697838_0
-  - r-climdex.pcic=1.1_11=r44h3697838_4
-  - r-climprojdiags=0.3.5=r44hc72bb7e_0
-  - r-codetools=0.2_20=r44hc72bb7e_2
-  - r-colorspace=2.1_2=r44h54b55ab_0
-  - r-contfrac=1.1_12=r44h54b55ab_1007
-  - r-cpp11=0.5.5=r44h785f33e_0
-  - r-crayon=1.5.3=r44hc72bb7e_2
-  - r-cyclocomp=1.1.2=r44hc72bb7e_0
-  - r-dbi=1.3.0=r44hc72bb7e_0
-  - r-desc=1.4.3=r44hc72bb7e_2
-  - r-desolve=1.42=r44h11cdb10_0
-  - r-digest=0.6.39=r44h3697838_0
-  - r-docopt=0.7.2=r44hc72bb7e_1
-  - r-doparallel=1.0.17=r44hc72bb7e_4
-  - r-dotcall64=1.2=r44heaba542_1
-  - r-e1071=1.7_17=r44h3697838_0
-  - r-ellipsis=0.3.3=r44h54b55ab_0
-  - r-elliptic=1.5_1=r44hc72bb7e_0
-  - r-evaluate=1.0.5=r44hc72bb7e_1
-  - r-fansi=1.0.7=r44h54b55ab_0
-  - r-farver=2.1.2=r44h3697838_2
-  - r-fields=17.3=r44heaba542_0
-  - r-foreach=1.5.2=r44hc72bb7e_4
-  - r-functional=0.7=r44hc72bb7e_0
-  - r-generics=0.1.4=r44hc72bb7e_1
-  - r-geomap=2.5_11=r44h54b55ab_2
-  - r-geomapdata=2.0_2=r44hc72bb7e_2
-  - r-ggplot2=4.0.3=r44h785f33e_0
-  - r-git2r=0.35.0=r44h4505f3e_0
-  - r-glue=1.8.1=r44h54b55ab_0
-  - r-goftest=1.2_3=r44h54b55ab_4
-  - r-gridextra=2.3.1=r44hc72bb7e_0
-  - r-gtable=0.3.6=r44hc72bb7e_1
-  - r-highr=0.12=r44hc72bb7e_0
-  - r-hypergeo=1.2_14=r44hc72bb7e_1
-  - r-isoband=0.3.0=r44h3697838_0
-  - r-iterators=1.0.14=r44hc72bb7e_4
-  - r-jsonlite=2.0.0=r44h54b55ab_1
-  - r-kernsmooth=2.23_26=r44ha0a88a1_1
-  - r-knitr=1.51=r44hc72bb7e_0
-  - r-labeling=0.4.3=r44hc72bb7e_2
-  - r-lattice=0.22_9=r44h54b55ab_0
-  - r-lazyeval=0.2.3=r44h54b55ab_0
-  - r-lifecycle=1.0.5=r44hc72bb7e_0
-  - r-lintr=3.1.2=r44hc72bb7e_1
-  - r-lisp=0.2=r44hc72bb7e_0
-  - r-lmom=3.3=r44heaba542_0
-  - r-lmomco=2.5.5=r44hc72bb7e_0
-  - r-lmoments=1.3_2=r44hf1899b2_0
-  - r-logging=0.10_111=r44hc72bb7e_0
-  - r-lubridate=1.9.5=r44h54b55ab_0
-  - r-magrittr=2.0.5=r44h54b55ab_0
-  - r-mapproj=1.2.12=r44h54b55ab_1
-  - r-maps=3.4.3=r44h54b55ab_1
-  - r-mass=7.3_65=r44h54b55ab_0
-  - r-mba=0.1_3=r44h3697838_0
-  - r-multiapply=2.1.5=r44hc72bb7e_1
-  - r-munsell=0.5.1=r44hc72bb7e_2
-  - r-nbclust=3.0.1=r44hc72bb7e_4
-  - r-ncdf4=1.24=r44h241fd4c_0
-  - r-ncdf4.helpers=0.3_7=r44hc72bb7e_1
-  - r-pcict=0.5_4.4=r44h54b55ab_3
-  - r-pillar=1.11.1=r44hc72bb7e_0
-  - r-pkgconfig=2.0.3=r44hc72bb7e_5
-  - r-plyr=1.8.9=r44h3697838_3
-  - r-processx=3.9.0=r44h54b55ab_0
-  - r-proxy=0.4_29=r44h54b55ab_0
-  - r-ps=1.9.3=r44h54b55ab_0
-  - r-purrr=1.2.2=r44h54b55ab_0
-  - r-r.cache=0.17.0=r44hc72bb7e_1
-  - r-r.methodss3=1.8.2=r44hc72bb7e_4
-  - r-r.oo=1.27.1=r44hc72bb7e_1
-  - r-r.utils=2.13.0=r44hc72bb7e_1
-  - r-r6=2.6.1=r44hc72bb7e_1
-  - r-rcolorbrewer=1.1_3=r44h785f33e_4
-  - r-rcpp=1.1.1_1.1=r44h3697838_0
-  - r-rcpparmadillo=15.4.0_1=r44h3704496_0
-  - r-rematch2=2.1.2=r44hc72bb7e_5
-  - r-remotes=2.5.0=r44hc72bb7e_2
-  - r-reshape=0.8.10=r44hc72bb7e_1
-  - r-rex=1.2.2=r44hc72bb7e_0
-  - r-rlang=1.2.0=r44h3697838_0
-  - r-rpmg=2.2_7=r44hc72bb7e_2
-  - r-rprojroot=2.1.1=r44hc72bb7e_1
-  - r-s2=1.1.7=r44h4b309dc_0
-  - r-s2dverification=2.10.3=r44hc72bb7e_4
-  - r-s7=0.2.2=r44h54b55ab_0
-  - r-scales=1.4.0=r44hc72bb7e_1
-  - r-sf=1.0_20=r44h4d3cc04_0
-  - r-snow=0.4_4=r44hc72bb7e_4
-  - r-sp=2.2_1=r44h54b55ab_0
-  - r-spam=2.11_4=r44h2ddecb4_0
-  - r-specsverification=0.5_3=r44h3697838_5
-  - r-spei=1.8.1=r44hc72bb7e_3
-  - r-styler=1.10.3=r44hc72bb7e_2
-  - r-tibble=3.3.1=r44h54b55ab_0
-  - r-timechange=0.4.0=r44h3697838_0
-  - r-tlmoments=0.7.5.3=r44h3697838_3
-  - r-udunits2=0.13.2.2=r44h54b55ab_1
-  - r-units=1.0_1=r44h3697838_0
-  - r-utf8=1.2.6=r44h54b55ab_1
-  - r-uuid=1.2_2=r44h54b55ab_0
-  - r-vctrs=0.7.3=r44h3697838_0
-  - r-viridislite=0.4.3=r44hc72bb7e_0
-  - r-withr=3.0.3=r44hc72bb7e_0
-  - r-wk=0.9.5=r44h3697838_0
-  - r-xfun=0.59=r44h54b55ab_0
-  - r-xml2=1.4.0=r44hc6fd541_1
-  - r-xmlparsedata=1.0.5=r44hc72bb7e_4
-  - r-yaml=2.3.12=r44h54b55ab_0
-  - r-zoo=1.8_15=r44h54b55ab_0
-  - rasterio=1.4.3=py312h8cae83d_0
-  - rasterstats=0.21.0=pyhcf101f3_0
-  - rattler-build=0.67.0=ha759004_0
-  - rav1e=0.7.1=h8fae777_3
-  - rdflib=7.6.0=pyhcf101f3_0
-  - rdma-core=63.0=h192683f_1
-  - re2=2024.07.02=h9925aae_2
-  - readline=8.3=h853b02a_0
-  - readme_renderer=45.0=pyhcf101f3_1
-  - rechunker=0.5.2=pyhd8ed1ab_2
-  - referencing=0.37.0=pyhcf101f3_0
-  - regex=2026.6.28=py312h4c3975b_0
-  - regional-mom6=1.0.1=pyhd8ed1ab_0
-  - regionmask=0.13.0=pyhd8ed1ab_0
-  - reproc=14.2.7.post0=hb03c661_1
-  - reproc-cpp=14.2.7.post0=hecca717_1
-  - requests=2.34.2=pyhcf101f3_0
-  - requests-cache=1.3.3=pyhd8ed1ab_0
-  - requests-oauthlib=2.0.0=pyhd8ed1ab_1
-  - requests-toolbelt=1.0.0=pyhd8ed1ab_1
-  - requestsexceptions=1.4.0=py_0
-  - requirements-detector=1.4.0=pyhd8ed1ab_0
-  - restructuredtext_lint=2.0.2=pyhd8ed1ab_0
-  - retrying=1.4.2=pyhe01879c_0
-  - rfc3339-validator=0.1.4=pyhd8ed1ab_1
-  - rfc3986=2.0.0=pyhd8ed1ab_1
-  - rfc3986-validator=0.1.1=pyh9f0ad1d_0
-  - rfc3987-syntax=1.1.0=pyhe01879c_1
-  - rich=15.0.0=pyhcf101f3_0
-  - rich-argparse=1.8.0=pyhd8ed1ab_0
-  - rioxarray=0.20.0=pyhd8ed1ab_1
-  - ripgrep=15.1.0=hdab8a38_0
-  - roaring-landmask=0.10.1=py312h1d298fb_1
-  - roman-numerals=4.1.0=pyhd8ed1ab_0
-  - rpds-py=2026.6.3=py312h192e038_0
-  - rsa=4.9.1=pyhd8ed1ab_0
-  - rtree=1.4.1=pyh11ca60a_0
-  - ruamel.yaml=0.18.17=py312h5253ce2_2
-  - ruamel.yaml.clib=0.2.15=py312h5253ce2_1
-  - ruff=0.15.20=h6a952e8_0
-  - s2geometry=0.11.1=he06fccc_3
-  - s2n=1.5.14=h6c98b2b_0
-  - s3fs=2026.6.0=pyhd8ed1ab_0
-  - safetensors=0.8.0=py312h868fb18_0
-  - satpy=0.60.0=pyhd8ed1ab_0
-  - scikit-image=0.26.0=np2py312h4ae17e4_0
-  - scikit-learn=1.8.0=np2py312h3226591_1
-  - scipy=1.17.1=py312h54fa4ab_1
-  - scores=2.5.0=pyhd8ed1ab_0
-  - scs=3.2.11=default_py312h250c4f3_1
-  - sdl2=2.32.54=h3f2d84a_0
-  - sdl3=3.2.14=he3e324a_0
-  - seaborn=0.13.2=hd8ed1ab_3
-  - seaborn-base=0.13.2=pyhd8ed1ab_3
-  - seawater=3.3.5=pyhd8ed1ab_1
-  - secretstorage=3.5.0=py312h7900ff3_0
-  - sed=4.10=h19d0853_0
-  - segregation=2.5.5=pyhd8ed1ab_0
-  - semver=3.0.4=pyhcf101f3_1
-  - send2trash=2.1.0=pyha191276_1
-  - setoptconf-tmp=0.3.1=pyhd8ed1ab_0
-  - setproctitle=1.3.7=py312h5253ce2_0
-  - setuptools=82.0.1=pyh332efcf_0
-  - setuptools-scm=10.2.0=pyhcf101f3_0
-  - setuptools_scm=10.2.0=he0c3440_0
-  - sh=2.2.4=pyh707e725_0
-  - shap=0.52.0=cpu_py312h303243a_0
-  - shapely=2.0.7=py312h391bc85_0
-  - shellcheck=0.11.0=ha770c72_1
-  - shellingham=1.5.4=pyhd8ed1ab_2
-  - shumlib=2026.07.2=h3218e01_0
-  - simdjson=3.12.3=h84d6215_0
-  - simpervisor=1.0.0=pyhd8ed1ab_1
-  - simplejson=4.1.1=py312h4c3975b_0
-  - sip=6.10.0=py312h1289d80_1
-  - siphash24=1.8=py312h4c3975b_2
-  - siphon=0.10.0=pyhd8ed1ab_1
-  - six=1.17.0=pyhe01879c_1
-  - slicer=0.0.8=pyhd8ed1ab_0
-  - smmap=5.0.3=pyhcf101f3_1
-  - snappy=1.2.2=h03e3b7b_1
-  - sniffio=1.3.1=pyhd8ed1ab_2
-  - snowballstemmer=3.1.1=pyhd8ed1ab_0
-  - snuggs=1.4.7=pyhd8ed1ab_2
-  - sortedcontainers=2.4.0=pyhd8ed1ab_1
-  - soupsieve=2.8.4=pyhd8ed1ab_0
-  - spaghetti=1.7.6=pyhd8ed1ab_1
-  - sparse=0.19.0=pyhc364b38_0
-  - spdlog=1.15.1=hb29a8c4_0
-  - spglm=1.1.0=pyhd8ed1ab_2
-  - sphinx=9.1.0=pyhd8ed1ab_0
-  - sphinxcontrib-applehelp=2.0.0=pyhd8ed1ab_1
-  - sphinxcontrib-devhelp=2.0.0=pyhd8ed1ab_1
-  - sphinxcontrib-htmlhelp=2.1.0=pyhd8ed1ab_1
-  - sphinxcontrib-jsmath=1.0.1=pyhd8ed1ab_1
-  - sphinxcontrib-qthelp=2.0.0=pyhd8ed1ab_1
-  - sphinxcontrib-serializinghtml=2.0.0=pyhd8ed1ab_0
-  - spint=1.1.0=pyhd8ed1ab_0
-  - splot=1.1.7=pyhd8ed1ab_1
-  - spopt=0.7.0=pyhd8ed1ab_0
-  - spreg=1.9.0=pyhd8ed1ab_0
-  - spvcm=0.3.0=pyhd8ed1ab_2
-  - spyder-kernels=3.1.5=unix_pyh707e725_0
-  - sqlalchemy=2.0.51=py312h5253ce2_0
-  - sqlite=3.53.3=hbc0de68_0
-  - stack_data=0.6.3=pyhd8ed1ab_1
-  - statsforecast=2.0.1=py312h68727a3_0
-  - statsmodels=0.14.6=py312h4f23490_0
-  - stevedore=5.9.0=pyhd8ed1ab_0
-  - svt-av1=3.0.2=h5888daf_0
-  - sympy=1.14.0=pyh2585a3b_106
-  - sysroot_linux-64=2.28=h4ee821c_9
-  - tabulate=0.10.0=pyhcf101f3_0
-  - tbb=2021.13.0=h8d10470_4
-  - tblib=3.2.2=pyhcf101f3_0
-  - tempest-remap=2.2.0=heeae502_5
-  - tenacity=9.1.4=pyhcf101f3_0
-  - tensorboard=2.18.0=pyhd8ed1ab_1
-  - tensorboard-data-server=0.7.0=py312h4eba8b5_4
-  - tensorboardx=2.6.2.2=pyhd8ed1ab_1
-  - tensorflow=2.18.0=cpu_py312h69ecde4_2
-  - tensorflow-base=2.18.0=cpu_py312h11d59fd_2
-  - tensorflow-estimator=2.18.0=cpu_py312h651dbe2_2
-  - termcolor=3.3.0=pyhd8ed1ab_0
-  - terminado=0.18.1=pyhc90fa1f_1
-  - threadpoolctl=3.6.0=pyhecae5ae_0
-  - tifffile=2025.12.12=pyhd8ed1ab_0
-  - tiledb=2.27.2=hab680f6_2
-  - time-machine=2.19.0=py312h5253ce2_2
-  - timezonefinder=8.2.4=py312h5253ce2_0
-  - tintx=2022.12.2=pyhd8ed1ab_0
-  - tinycss2=1.4.0=pyhd8ed1ab_0
-  - tk=8.6.13=noxft_h366c992_103
-  - tktable=2.10=h5a7a40f_8
-  - tobler=0.14.0=pyhd8ed1ab_0
-  - toml=0.10.2=pyhcf101f3_3
-  - tomli=2.4.1=pyhcf101f3_0
-  - tomli-w=1.2.0=pyhd8ed1ab_0
-  - tomlkit=0.15.0=pyha770c72_0
-  - toolz=1.1.0=pyhd8ed1ab_1
-  - torchmetrics=1.9.0=pyhd8ed1ab_0
-  - torchtriton=3.1.0=py312
-  - tornado=6.5.7=py312h4c3975b_0
-  - tqdm=4.68.3=pyh8f84b5b_0
-  - traitlets=5.15.1=pyhcf101f3_0
-  - traits=7.1.0=py312h4c3975b_0
-  - traitsui=8.0.0=pyhd8ed1ab_1
-  - traittypes=0.2.3=pyh332efcf_0
-  - trajan=0.11.0=pyhd8ed1ab_0
-  - triad=1.0.2=pyhcf101f3_0
-  - trollimage=1.28.0=py312hf79963d_0
-  - trollsift=1.0.1=pyhd8ed1ab_0
-  - trove-classifiers=2026.6.1.19=pyhcf101f3_0
-  - truststore=0.10.4=pyhcf101f3_0
-  - twine=6.2.0=pyhcf101f3_0
-  - typeguard=4.5.2=pyhcf101f3_0
-  - typer=0.26.8=pyhcf101f3_0
-  - typing-extensions=4.16.0=h69aa097_0
-  - typing-inspection=0.4.2=pyhcf101f3_2
-  - typing_extensions=4.16.0=pyhcf101f3_0
-  - typing_inspect=0.9.0=pyhd8ed1ab_1
-  - typing_utils=0.1.0=pyhd8ed1ab_1
-  - tzcode=2026b=h280c20c_0
-  - tzdata=2025c=hc9c84f9_1
-  - tzlocal=5.4.4=pyh8f84b5b_0
-  - u8darts=0.45.0=pyhd8ed1ab_0
-  - u8darts-all=0.45.0=pyhd8ed1ab_0
-  - uc-micro-py=2.0.0=pyhcf101f3_0
-  - ucc=1.4.4=h85763d7_1
-  - ucx=1.18.1=h990bcc0_2
-  - ucx-py=0.45.00=py312_250806_d53bdda0
-  - udunits2=2.2.28=h40f5838_3
-  - ujson=5.13.0=py312h8285ef7_0
-  - ukkonen=1.1.0=py312hd9148b4_0
-  - ultraplot=2.3.0=pyhd8ed1ab_0
-  - uncertainties=3.2.3=pyhd8ed1ab_0
-  - uncompresspy=0.4.1=pyhd8ed1ab_0
-  - unearth=0.18.2=pyhd8ed1ab_0
-  - unicodedata2=17.0.1=py312h4c3975b_0
-  - universal-pathlib=0.3.10=hd8ed1ab_0
-  - universal_pathlib=0.3.10=pyhd8ed1ab_0
-  - untokenize=0.1.1=pyhcf101f3_3
-  - uri-template=1.3.0=pyhd8ed1ab_1
-  - uriparser=0.9.8=hac33072_0
-  - uritools=6.1.2=pyhd8ed1ab_0
-  - url-normalize=3.0.0=pyhd8ed1ab_0
-  - urllib3=2.5.0=pyhd8ed1ab_0
-  - utfcpp=4.09=ha770c72_0
-  - utilsforecast=0.2.16=pyhd8ed1ab_0
-  - validators=0.35.0=pyhd8ed1ab_0
-  - varint=1.0.2=pyhd8ed1ab_1
-  - vcs_versioning=2.2.2=pyhcf101f3_0
-  - versioneer=0.29=pyhd8ed1ab_0
-  - virtualenv=20.39.0=pyhcf101f3_0
-  - virtualizarr=2.7.0=pyhd8ed1ab_0
-  - vtk=9.3.1=qt_py312h71fb23e_216
-  - vtk-base=9.3.1=qt_py312h6cb585f_216
-  - vtk-io-ffmpeg=9.3.1=qt_py312h71fb23e_216
-  - watchdog=6.0.0=py312h20c3967_3
-  - watermark=2.6.0=pyhcf101f3_0
-  - wavespectra=4.5.1=py312h3f74e48_0
-  - wayland=1.25.0=hd6090a7_0
-  - wayland-protocols=1.49=hd8ed1ab_0
-  - wcwidth=0.8.2=pyhd8ed1ab_0
-  - webcolors=25.10.0=pyhd8ed1ab_0
-  - webencodings=0.5.1=pyhd8ed1ab_3
-  - webob=1.8.10=pyhd8ed1ab_0
-  - websocket-client=1.9.0=pyhd8ed1ab_0
-  - werkzeug=3.1.8=pyhcf101f3_0
-  - wheel=0.47.0=pyhd8ed1ab_0
-  - widgetsnbextension=4.0.15=pyhd8ed1ab_0
-  - windspharm=2.0.0=pyhd8ed1ab_1
-  - wradlib=2.8.0=pyhd8ed1ab_0
-  - wrapt=2.2.2=py312h4c3975b_0
-  - wrf-python=1.4.2=py312h6a55c13_2
-  - wslink=2.5.7=pyhd8ed1ab_0
-  - wurlitzer=3.1.1=pyhd8ed1ab_1
-  - x264=1!164.3095=h166bdaf_2
-  - x265=3.5=h924138e_3
-  - xarray=2026.1.0=pyhcf101f3_0
-  - xarray-einstats=0.10.0=pyhd8ed1ab_0
-  - xarray-spatial=0.10.15=pyhd8ed1ab_0
-  - xarraymannkendall=1.4.5=pyhd8ed1ab_0
-  - xcb-util=0.4.1=h4f16b4b_2
-  - xcb-util-cursor=0.1.6=hb03c661_0
-  - xcb-util-image=0.4.0=hb711507_2
-  - xcb-util-keysyms=0.4.1=hb711507_0
-  - xcb-util-renderutil=0.3.10=hb711507_0
-  - xcb-util-wm=0.4.2=hb711507_0
-  - xcdat=0.11.2=pyhd8ed1ab_1
-  - xclim=0.61.1=pyhd8ed1ab_0
-  - xclip=0.13=hb9d3cd8_4
-  - xerces-c=3.2.5=h988505b_2
-  - xesmf=0.9.2=pyhd8ed1ab_0
-  - xgboost=3.3.0=cpu_pyhb39878e_0
-  - xgcm=0.9.0=pyhd8ed1ab_0
-  - xhistogram=0.3.2=pyhd8ed1ab_0
-  - xkeyboard-config=2.48=h280c20c_0
-  - xlsxwriter=3.2.9=pyhd8ed1ab_0
-  - xmip=0.7.2=pyhd8ed1ab_1
-  - xmitgcm=0.5.2=pyhd8ed1ab_1
-  - xmltodict=1.0.4=pyhcf101f3_0
-  - xmovie=0.3.1=pyhd8ed1ab_0
-  - xorg-imake=1.0.11=hecca717_0
-  - xorg-libice=1.1.2=hb9d3cd8_0
-  - xorg-libsm=1.2.6=he73a12e_0
-  - xorg-libx11=1.8.13=he1eb515_0
-  - xorg-libxau=1.0.12=hb03c661_1
-  - xorg-libxaw=1.0.16=hb9d3cd8_0
-  - xorg-libxcomposite=0.4.7=hb03c661_0
-  - xorg-libxcursor=1.2.3=hb9d3cd8_0
-  - xorg-libxdamage=1.1.6=hb9d3cd8_0
-  - xorg-libxdmcp=1.1.5=hb03c661_1
-  - xorg-libxext=1.3.7=hb03c661_0
-  - xorg-libxfixes=6.0.2=hb03c661_0
-  - xorg-libxi=1.8.3=hb03c661_0
-  - xorg-libxinerama=1.1.6=hecca717_0
-  - xorg-libxmu=1.3.1=hb03c661_0
-  - xorg-libxpm=3.5.19=hb03c661_0
-  - xorg-libxrandr=1.5.5=hb03c661_0
-  - xorg-libxrender=0.9.12=hb9d3cd8_0
-  - xorg-libxscrnsaver=1.2.4=hb9d3cd8_0
-  - xorg-libxt=1.3.1=hb9d3cd8_0
-  - xorg-libxtst=1.2.5=hb9d3cd8_3
-  - xorg-libxxf86vm=1.1.7=hb03c661_0
-  - xorg-makedepend=1.0.9=hecca717_0
-  - xorg-xorgproto=2025.1=hb03c661_0
-  - xradar=0.12.0=pyhd8ed1ab_0
-  - xrft=1.0.2=pyhd8ed1ab_0
-  - xsdba=0.7.0=pyhd8ed1ab_0
-  - xsel=1.2.1=hb9d3cd8_6
-  - xskillscore=0.0.29=pyhd8ed1ab_0
-  - xwrf=0.0.5=pyhd8ed1ab_0
-  - xxhash=0.8.3=hb47aa4a_0
-  - xyzservices=2026.3.0=pyhd8ed1ab_0
-  - xz=5.8.3=ha02ee65_0
-  - xz-gpl-tools=5.8.3=ha02ee65_0
-  - xz-tools=5.8.3=hb03c661_0
-  - yamale=6.1.0=pyhd8ed1ab_0
-  - yamanifest=0.3.13=py_0
-  - yaml=0.2.5=h280c20c_3
-  - yaml-cpp=0.8.0=h3f2d84a_0
-  - yamllint=1.35.1=pyhd8ed1ab_1
-  - yapf=0.43.0=pyhd8ed1ab_1
-  - yarl=1.24.2=py312h8a5da7c_0
-  - zarr=3.2.1=pyhc364b38_0
-  - zeromq=4.3.5=h387f397_9
-  - zfp=1.0.1=h909a3a2_5
-  - zict=3.0.0=pyhd8ed1ab_1
-  - zipp=4.1.0=pyhcf101f3_0
-  - zlib=1.3.2=h25fd6f3_2
-  - zlib-ng=2.2.5=hde8ca8f_1
-  - zstandard=0.25.0=py312h5253ce2_1
-  - zstd=1.5.7=hb78ec9c_6
-  - pip
-  - pip:
-    - accessvis==1.1.4
-    - cc-plugin-wcrp==2.3.2
-    - cmip7-data-request-api==1.4
-    - cmip7-repack==1.1.0
-    - esgvoc==4.2.0
-    - frisky==0.1.1
-    - lavavu==1.9.10
-    - lavavu-osmesa==1.9.10
-    - nci-ipynb==2023.11.0.3
-    - py360convert==1.0.4
-    - pycnv==0.5.0
-    - pyld==3.1.0
-    - railroad-diagrams==3.0.1
-    - sqlmodel==0.0.39
-    - wget==3.2
+- shumlib ==2026.7.2 h3218e01_0
+- access-intake-esm ==2026.7.1 py_0
+- access-intake-utils ==0.1.7 py_0
+- access-med-tools ==0.1.23 pypy_0
+- access-moppy ==1.6.6b py_0
+- access-moppy-esmval ==1.6.6b 0
+- access-nri-intake ==1.6.2 py_0
+- access-py-telemetry ==0.1.10 py_0
+- ecgtools-access ==2025.10.7 py_0
+- intake-esm-access ==2026.4.15 py_0
+- intake-virtual-icechunk ==0.2.2 py_0
+- yamanifest ==0.3.13 py_0
+- pygamma_n ==1.0.0 py312h4cfd3ad_1
+- _openmp_mutex ==4.5 7_kmp_llvm
+- aiohttp ==3.14.1 py312h5d8c7f2_0
+- alsa-lib ==1.2.16.1 hb03c661_0
+- aom ==3.9.1 hac33072_0
+- arch-py ==8.0.0 py312h4f23490_0
+- argon2-cffi-bindings ==25.1.0 py312h4c3975b_2
+- arm_pyart ==2.2.4 py312h4c3975b_0
+- astroid ==4.0.4 py312h7900ff3_0
+- astropy-base ==8.0.0 py312h4f23490_0
+- at-spi2-atk ==2.38.0 h0630a04_3
+- at-spi2-core ==2.40.3 h0630a04_0
+- atk-1.0 ==2.38.0 h04ea711_2
+- av ==15.1.0 py312hdd571cc_0
+- aws-c-auth ==0.8.6 hd08a7f5_4
+- aws-c-cal ==0.8.7 h043a21b_0
+- aws-c-common ==0.12.0 hb9d3cd8_0
+- aws-c-compression ==0.3.1 h3870646_2
+- aws-c-event-stream ==0.5.4 h04a3f94_2
+- aws-c-http ==0.9.4 hb9b18c6_4
+- aws-c-io ==0.17.0 h3dad3f2_6
+- aws-c-mqtt ==0.12.2 h108da3e_2
+- aws-c-s3 ==0.7.13 h822ba82_2
+- aws-c-sdkutils ==0.2.3 h3870646_2
+- aws-checksums ==0.2.3 h3870646_2
+- aws-crt-cpp ==0.31.0 h55f77e1_4
+- aws-sdk-cpp ==1.11.510 h37a5c72_3
+- azure-core-cpp ==1.14.0 h5cfcd09_0
+- azure-identity-cpp ==1.10.0 h113e628_0
+- azure-storage-blobs-cpp ==12.13.0 h3cf044e_1
+- azure-storage-common-cpp ==12.8.0 h736e048_1
+- azure-storage-files-datalake-cpp ==12.12.0 ha633028_1
+- backports.zoneinfo ==0.2.1 py312h7900ff3_11
+- backports.zstd ==1.6.0 py312h90b7ffd_0
+- binutils_impl_linux-64 ==2.45.1 default_hfdba357_102
+- binutils_linux-64 ==2.45.1 default_h4852527_102
+- blake3 ==1.0.9 py312h868fb18_0
+- blas ==1.0 mkl
+- blosc ==1.21.6 he440d0b_1
+- bottleneck ==1.6.0 np2py312hfb8c2c5_3
+- brotli ==1.1.0 hb03c661_4
+- brotli-bin ==1.1.0 hb03c661_4
+- brotli-python ==1.1.0 py312h1289d80_4
+- brunsli ==0.1 he3183e4_1
+- bwidget ==1.10.1 ha770c72_1
+- bzip2 ==1.0.8 hda65f42_9
+- c-ares ==1.34.6 hb03c661_0
+- c-blosc2 ==2.17.1 h3122c55_0
+- c-compiler ==1.0.0 h14c3975_0
+- cairo ==1.18.4 h3394656_0
+- capnproto ==1.0.2 h766bdaa_3
+- cartopy ==0.25.0 py312hf79963d_1
+- catboost ==1.2.10 cuda120_py312hd5f8c11_100
+- cdo ==2.5.0 hc8165f4_0
+- cf-python ==3.20.0 py312h3111c9b_0
+- cf-units ==3.3.1 py312h4f23490_0
+- cfdm ==1.13.1.0 py312h7900ff3_0
+- cffi ==2.0.0 py312h460c074_1
+- cfitsio ==4.5.0 h44b4e7a_0
+- cftime ==1.6.5 py312h4f23490_1
+- charls ==2.4.4 hecca717_0
+- clarabel ==0.11.1 py312h0ccc70a_2
+- cmd2 ==3.5.1 py312h7900ff3_0
+- cmor ==3.10.0 py312h9ea2cd8_0
+- coin-or-cbc ==2.10.13 h4d16d09_1
+- coin-or-cgl ==0.60.10 hc46dffc_1
+- coin-or-clp ==1.17.11 hc03379b_1
+- coin-or-osi ==0.108.12 hf4fecb4_1
+- coin-or-utils ==2.11.13 hc93afbd_1
+- comrak ==0.53.0 hb17b654_0
+- conda ==26.5.3 py312h20c3967_2
+- conda-pypi ==0.11.0 py312h20c3967_0
+- contourpy ==1.3.3 py312h0a2e395_4
+- coreforecast ==0.0.17 py312hd9148b4_0
+- coverage ==7.15.0 py312h8a5da7c_0
+- cpp-expected ==1.1.0 hff21bea_1
+- crick ==0.0.8 py312hc0a28a1_0
+- cryptography ==49.0.0 py312ha4b625e_0
+- cuda-cudart ==12.4.127 he02047a_2
+- cuda-cupti ==12.4.127 he02047a_2
+- cuda-libraries ==12.4.1 ha770c72_1
+- cuda-nvrtc ==12.4.127 he02047a_2
+- cuda-nvtx ==12.4.127 he02047a_2
+- cuda-opencl ==12.4.127 he02047a_1
+- cupy ==13.4.1 py312h78400a1_0
+- cupy-core ==13.4.1 py312h007fbcc_0
+- curl ==8.18.0 h4e3cde8_0
+- cvxpy ==1.9.1 py312h4f8cda9_0
+- cvxpy-base ==1.9.1 np2py312h0f77346_0
+- cyrus-sasl ==2.1.28 hd9c7081_0
+- cython ==3.2.8 py312h68e6be4_0
+- cytoolz ==1.1.0 py312h4c3975b_2
+- dav1d ==1.2.1 hd590300_0
+- dbus ==1.13.6 h5008d03_3
+- dcw-gmt ==2.2.0 ha770c72_0
+- debugpy ==1.8.21 py312h8285ef7_0
+- double-conversion ==3.3.1 h5888daf_0
+- dulwich ==0.24.10 py312h0ccc70a_1
+- eccodes ==2.41.0 h8bb6dbc_0
+- epoxy ==1.5.10 hb03c661_2
+- esmf ==8.8.1 mpi_openmpi_h461c5ee_0
+- expat ==2.8.1 hecca717_1
+- fast-histogram ==0.14 py312h4f23490_4
+- fastrlock ==0.8.3 py312h8285ef7_2
+- ffmpeg ==7.1.1 gpl_h0b79d52_704
+- fftw ==3.3.11 nompi_h3b011a4_100
+- fiona ==1.10.1 py312h02b19dd_3
+- flatbuffers ==24.12.23 h8f4948b_0
+- fmt ==11.0.2 h07f6e7f_1
+- fontconfig ==2.18.1 h27c8c51_0
+- fonttools ==4.63.0 py312h8a5da7c_0
+- freeglut ==3.2.2 h215f996_4
+- freetype ==2.14.3 ha770c72_0
+- freexl ==2.0.0 h9dce30a_2
+- fribidi ==1.0.16 hb03c661_0
+- frozenlist ==1.8.0 py312h447239a_0
+- gcc_impl_linux-64 ==15.2.0 he0086c7_19
+- gcc_linux-64 ==15.2.0 h7be306e_27
+- gdal ==3.10.2 py312hc55c449_5
+- gdk-pixbuf ==2.42.12 hb9ae30d_0
+- geos ==3.13.0 h5888daf_0
+- geotiff ==1.7.4 h3551947_0
+- gettext ==0.25.1 h3f43e3d_1
+- gettext-tools ==0.25.1 h3f43e3d_1
+- gflags ==2.2.2 h5888daf_1005
+- gfortran_impl_linux-64 ==15.2.0 h281d09f_19
+- ghostscript ==10.7.1 hecca717_0
+- giflib ==5.2.2 hd590300_0
+- gl2ps ==1.4.2 h36e74d4_2
+- glcontext ==3.0.0 py312h1289d80_3
+- glew ==2.1.0 h9c3ff4c_2
+- glib ==2.84.0 h07242d1_0
+- glib-tools ==2.84.0 h4833e2c_0
+- glog ==0.7.1 hbabe93e_0
+- gmp ==6.3.0 hac33072_2
+- gmpy2 ==2.3.0 py312hcaba1f9_1
+- gmt ==6.5.0 h4b96b86_7
+- google-crc32c ==1.8.0 py312h03f33d3_1
+- graphite2 ==1.3.15 hecca717_0
+- graphviz ==12.2.1 h5ae0cbf_1
+- greenlet ==3.5.3 py312h8285ef7_0
+- gridfill ==1.1.1 py312h4f23490_4
+- grpcio ==1.67.1 py312hacea422_2
+- gshhg-gmt ==2.3.7 ha770c72_1003
+- gsl ==2.7 he838d99_0
+- gst-plugins-base ==1.24.7 h0a52356_0
+- gstreamer ==1.24.7 hf3bb09a_0
+- gsw ==3.6.23 h7c397b8_0
+- gtk3 ==3.24.43 h0c6a113_5
+- gts ==0.7.6 h977cf35_4
+- gxx_impl_linux-64 ==15.2.0 hda75c37_19
+- h3 ==4.3.0 h3e4d06c_1
+- h3-py ==4.3.0 py312h8285ef7_3
+- h5py ==3.13.0 nompi_py312hedeef09_100
+- harfbuzz ==11.0.0 h76408a6_0
+- hdbscan ==0.8.44 py312h4f23490_0
+- hdf4 ==4.2.15 h2a13503_7
+- hdf5 ==1.14.3 mpi_openmpi_h39ae36c_9
+- hdfeos2 ==2.20 h3e53b52_1004
+- hdfeos5 ==5.1.16 h51d0b48_17
+- hf-xet ==1.5.1 py310hb823017_0
+- hicolor-icon-theme ==0.17 ha770c72_3
+- highspy ==1.14.0 np2py312h0f77346_0
+- icechunk ==2.1.0 py312h0ccc70a_0
+- icu ==75.1 he02047a_0
+- ilamb ==2.7.3 py312h7900ff3_0
+- imagecodecs ==2025.3.30 py312hbc2ce58_0
+- imagemagick ==7.1.1_47 imagemagick_hf2058d9_0
+- imath ==3.1.12 h7955e40_0
+- jags ==4.3.2 h647a790_1
+- jasper ==4.2.9 h1588d4d_1
+- jbig ==2.1 h7f98852_2003
+- jq ==1.8.2 h280c20c_0
+- json-c ==0.18 h6688a6e_0
+- jsoncpp ==1.9.6 hf42df4d_1
+- jxrlib ==1.1 hd590300_3
+- kealib ==1.6.1 he902fbf_0
+- keyutils ==1.6.3 hb9d3cd8_0
+- kiwisolver ==1.5.0 py312h0a2e395_0
+- knem-headers ==1.1.4 ha770c72_2
+- krb5 ==1.21.3 h659f571_0
+- lame ==3.100 h166bdaf_1003
+- lcms2 ==2.19.1 h0c24ade_1
+- ld_impl_linux-64 ==2.45.1 default_hbd61a6d_102
+- lerc ==4.1.0 hdb68285_0
+- level-zero ==1.29.0 hb700be7_0
+- lftp ==4.9.3 h81d5518_2
+- libabseil ==20240722.0 cxx17_hbbce691_4
+- libaec ==1.1.5 h088129d_0
+- libarchive ==3.7.7 h75ea233_4
+- libarrow ==19.0.1 hc7b3859_3_cpu
+- libarrow-acero ==19.0.1 hcb10f89_3_cpu
+- libarrow-dataset ==19.0.1 hcb10f89_3_cpu
+- libarrow-substrait ==19.0.1 h08228c5_3_cpu
+- libasprintf ==0.25.1 h3f43e3d_1
+- libasprintf-devel ==0.25.1 h3f43e3d_1
+- libass ==0.17.3 h52826cd_2
+- libavif16 ==1.3.0 h766b0b6_0
+- libblas ==3.9.0 20_linux64_mkl
+- libboost ==1.90.0 hed09d94_0
+- libbrotlicommon ==1.1.0 hb03c661_4
+- libbrotlidec ==1.1.0 hb03c661_4
+- libbrotlienc ==1.1.0 hb03c661_4
+- libcap ==2.78 hd0affe5_0
+- libcblas ==3.9.0 20_linux64_mkl
+- libcbor ==0.10.2 hcb278e6_0
+- libclang-cpp20.1 ==20.1.8 default_h99862b1_16
+- libclang13 ==21.1.0 default_h746c552_1
+- libcrc32c ==1.1.2 h9c3ff4c_0
+- libcst ==1.8.6 py312h121d7ae_1
+- libcublas ==12.4.5.8 he02047a_2
+- libcufft ==11.2.1.3 he02047a_2
+- libcufile ==1.9.1.3 he02047a_2
+- libcups ==2.3.3 hb8b1518_5
+- libcurand ==10.3.5.147 he02047a_2
+- libcurl ==8.18.0 h4e3cde8_0
+- libcusolver ==11.6.1.9 he02047a_2
+- libcusparse ==12.3.1.170 he02047a_2
+- libde265 ==1.0.15 h00ab1b0_0
+- libdeflate ==1.25 h17f619e_0
+- libdrm ==2.4.127 hb03c661_0
+- libedit ==3.1.20250104 pl5321h7949ede_0
+- libegl ==1.7.0 ha4b6fd6_3
+- libegl-devel ==1.7.0 ha4b6fd6_3
+- libev ==4.33 hd590300_2
+- libevent ==2.1.12 hf998b51_1
+- libexpat ==2.8.1 hecca717_1
+- libfabric ==2.6.0 ha770c72_0
+- libfabric1 ==2.6.0 h6b3ec72_0
+- libffi ==3.5.2 h3435931_0
+- libfido2 ==1.17.0 h8c08ba8_0
+- libflac ==1.5.0 he200343_1
+- libfreetype ==2.14.3 ha770c72_0
+- libfreetype6 ==2.14.3 h73754d4_0
+- libgcc ==15.2.0 he0feb66_19
+- libgcc-ng ==15.2.0 h69a702a_19
+- libgd ==2.3.3 h6f5c62b_11
+- libgdal ==3.10.2 hea5fcb0_5
+- libgdal-core ==3.10.2 h3359108_0
+- libgdal-fits ==3.10.2 h872822d_0
+- libgdal-grib ==3.10.2 h724c1be_0
+- libgdal-hdf4 ==3.10.2 h05c48c5_0
+- libgdal-hdf5 ==3.10.2 hf0b1780_0
+- libgdal-jp2openjpeg ==3.10.2 ha1d2769_0
+- libgdal-kea ==3.10.2 h41c5bbd_0
+- libgdal-netcdf ==3.10.2 ha1d9371_0
+- libgdal-pdf ==3.10.2 h8221dc3_0
+- libgdal-pg ==3.10.2 ha83508c_0
+- libgdal-postgisraster ==3.10.2 ha83508c_0
+- libgdal-tiledb ==3.10.2 h30425e6_0
+- libgdal-xls ==3.10.2 h5b36e33_0
+- libgettextpo ==0.25.1 h3f43e3d_1
+- libgettextpo-devel ==0.25.1 h3f43e3d_1
+- libgfortran ==15.2.0 h69a702a_19
+- libgfortran-ng ==15.2.0 h69a702a_19
+- libgfortran5 ==15.2.0 h68bc16d_19
+- libgit2 ==1.9.0 h502187d_1
+- libgl ==1.7.0 ha4b6fd6_3
+- libgl-devel ==1.7.0 ha4b6fd6_3
+- libglib ==2.84.0 h2ff4ddf_0
+- libglu ==9.0.3 h5888daf_1
+- libglvnd ==1.7.0 ha4b6fd6_3
+- libglx ==1.7.0 ha4b6fd6_3
+- libglx-devel ==1.7.0 ha4b6fd6_3
+- libgomp ==15.2.0 he0feb66_19
+- libgoogle-cloud ==2.36.0 h2b5623c_0
+- libgoogle-cloud-storage ==2.36.0 h0121fbd_0
+- libgrpc ==1.67.1 h25350d4_2
+- libheif ==1.19.7 gpl_hc18d805_100
+- libhwloc ==2.12.1 default_h3d81e11_1000
+- libhwy ==1.3.0 h4c17acf_1
+- libiconv ==1.18 h3b78370_2
+- libjpeg-turbo ==3.1.4.1 hb03c661_0
+- libjxl ==0.11.1 h6cb5226_4
+- libkml ==1.3.0 haa4a5bd_1023
+- liblapack ==3.9.0 20_linux64_mkl
+- liblapacke ==3.9.0 20_linux64_mkl
+- liblief ==0.17.6 hecca717_0
+- liblightgbm ==4.6.0 cpu_hf025404_8
+- libllvm20 ==20.1.8 hecd9e04_0
+- libllvm21 ==21.1.0 hecd9e04_0
+- liblzma ==5.8.3 hb03c661_0
+- liblzma-devel ==5.8.3 hb03c661_0
+- libmagic ==5.48 h421ea60_1
+- libmamba ==2.0.8 hf3fef5c_0
+- libmambapy ==2.0.8 py312h1d7e3b0_0
+- libmo_unpack ==3.1.2 hf484d3e_1001
+- libnetcdf ==4.9.2 mpi_openmpi_ha1e512f_14
+- libnghttp2 ==1.68.1 h877daf1_0
+- libnl ==3.11.0 hb9d3cd8_0
+- libnpp ==12.2.5.30 he02047a_2
+- libnsl ==2.0.1 hb9d3cd8_1
+- libntlm ==1.8 hb9d3cd8_0
+- libnvfatbin ==12.4.127 he02047a_2
+- libnvjitlink ==12.4.127 he02047a_2
+- libnvjpeg ==12.3.1.117 he02047a_2
+- libogg ==1.3.5 hd0c01bc_1
+- libopenblas ==0.3.33 pthreads_h94d23a6_0
+- libopencv ==4.11.0 qt6_py312h8ec186b_602
+- libopengl ==1.7.0 ha4b6fd6_3
+- libopentelemetry-cpp ==1.18.0 hfcad708_1
+- libopentelemetry-cpp-headers ==1.18.0 ha770c72_1
+- libopenvino ==2025.0.0 hdc3f47d_2
+- libopenvino-auto-batch-plugin ==2025.0.0 h4d9b6c2_2
+- libopenvino-auto-plugin ==2025.0.0 h4d9b6c2_2
+- libopenvino-hetero-plugin ==2025.0.0 h981d57b_2
+- libopenvino-intel-cpu-plugin ==2025.0.0 hdc3f47d_2
+- libopenvino-intel-gpu-plugin ==2025.0.0 hdc3f47d_2
+- libopenvino-intel-npu-plugin ==2025.0.0 hdc3f47d_2
+- libopenvino-ir-frontend ==2025.0.0 h981d57b_2
+- libopenvino-onnx-frontend ==2025.0.0 h6363af5_2
+- libopenvino-paddle-frontend ==2025.0.0 h6363af5_2
+- libopenvino-pytorch-frontend ==2025.0.0 h5888daf_2
+- libopenvino-tensorflow-frontend ==2025.0.0 h630ec5c_2
+- libopenvino-tensorflow-lite-frontend ==2025.0.0 h5888daf_2
+- libopus ==1.6.1 h280c20c_0
+- libosqp ==1.0.0 np2py312h1a77e3e_2
+- libparquet ==19.0.1 h081d1f1_3_cpu
+- libpciaccess ==0.19 hb03c661_0
+- libpmix ==5.0.8 h4bd6b51_2
+- libpnetcdf ==1.13.0 mpi_openmpi_h521bef2_1
+- libpng ==1.6.58 h421ea60_0
+- libpq ==17.6 h3675c94_1
+- libprotobuf ==5.28.3 h6128344_1
+- libqdldl ==0.1.8 h3f2d84a_1
+- libre2-11 ==2024.7.2 hbbce691_2
+- librsvg ==2.58.4 he92a37e_3
+- librttopo ==1.1.0 h97f6797_17
+- libsanitizer ==15.2.0 h90f66d4_19
+- libsndfile ==1.2.2 hc7d488a_2
+- libsodium ==1.0.20 h4ab18f5_0
+- libsolv ==0.7.30 h3509ff9_0
+- libspatialindex ==2.1.0 h54a6638_1
+- libspatialite ==5.1.0 h1b4f908_12
+- libsqlite ==3.53.3 h0c1763c_0
+- libssh2 ==1.11.1 hcf80075_0
+- libstdcxx ==15.2.0 h934c35e_19
+- libstdcxx-ng ==15.2.0 hdf11a46_19
+- libsystemd0 ==257.13 h084b8d7_1
+- libtensorflow_cc ==2.18.0 cpu_h739b781_2
+- libtensorflow_framework ==2.18.0 cpu_h417b707_2
+- libtheora ==1.1.1 h4ab18f5_1006
+- libthrift ==0.21.0 h0e7cc3e_0
+- libtiff ==4.7.2 h9d88235_0
+- libudev1 ==257.13 h084b8d7_1
+- libudunits2 ==2.2.28 h40f5838_3
+- libunwind ==1.6.2 h9c3ff4c_0
+- liburing ==2.9 h84d6215_0
+- libusb ==1.0.29 h73b1eb8_0
+- libutf8proc ==2.10.0 h202a827_0
+- libuuid ==2.42.2 h5347b49_0
+- libuv ==1.52.1 h280c20c_0
+- libva ==2.24.0 he1eb515_0
+- libvorbis ==1.3.7 h54a6638_2
+- libvpx ==1.14.1 hac33072_0
+- libwebp ==1.6.0 h9635ea4_0
+- libwebp-base ==1.6.0 hd42ef1d_0
+- libxcb ==1.17.0 h8a09558_0
+- libxcrypt ==4.4.36 hd590300_1
+- libxgboost ==3.3.0 cpu_h2ebb00f_0
+- libxkbcommon ==1.11.0 he8b52b9_0
+- libxml2 ==2.13.9 h04c0eec_0
+- libxslt ==1.1.43 h7a3aeb2_0
+- libzip ==1.11.2 h6991a6a_0
+- libzlib ==1.3.2 h25fd6f3_2
+- libzopfli ==1.0.3 h9c3ff4c_0
+- line_profiler ==5.0.2 py312h0a2e395_0
+- llvm-openmp ==15.0.7 h0cdce71_0
+- llvmlite ==0.47.0 py312h7424e68_1
+- lxml ==6.0.2 py312h70dad80_0
+- lz4 ==4.4.5 py312h3d67a73_1
+- lz4-c ==1.10.0 h5888daf_1
+- lzo ==2.10 h280c20c_1002
+- magics ==4.15.5 hc87abea_0
+- make ==4.4.1 hb9d3cd8_2
+- mamba ==2.0.8 h3f3603c_0
+- markupsafe ==3.0.3 py312h8a5da7c_1
+- matplotlib ==3.10.9 py312h7900ff3_0
+- matplotlib-base ==3.10.9 py312he3d6523_0
+- mayavi ==4.8.2 pyqt_py312h040c957_309
+- mbedtls ==3.6.3.1 h5888daf_0
+- menuinst ==2.5.1 py312h20c3967_0
+- minizip ==4.2.2 hb71707f_0
+- mkl ==2023.2.0 ha770c72_50498
+- ml_dtypes ==0.4.0 py312hf9745cd_2
+- mmh3 ==5.2.1 py312h1289d80_0
+- mo_pack ==0.3.1 py312h4f23490_2
+- moderngl ==5.12.0 py312hf79963d_0
+- mpc ==1.4.0 he0a73b1_0
+- mpfr ==4.2.2 he0a73b1_0
+- mpg123 ==1.32.9 hc50e24c_0
+- mpi ==1.0 openmpi
+- mpi4py ==4.1.2 py312hd140a38_100
+- msgpack-python ==1.2.1 py312h0a2e395_1
+- multidict ==6.7.1 py312h8a5da7c_0
+- mysql-common ==9.0.1 h266115a_6
+- mysql-libs ==9.0.1 he0572af_6
+- ncdu ==1.22 h18c060e_0
+- ncl ==6.6.2 ha9e1b40_55
+- nco ==5.3.3 h657489c_0
+- ncplot ==0.3.10 py312he8689d4_4
+- nctoolkit ==1.3.0 py312h7900ff3_0
+- ncurses ==6.6 hdb14827_0
+- netcdf-fortran ==4.6.1 mpi_openmpi_h2e02aee_8
+- netcdf4 ==1.7.2 nompi_py312h21d6d8e_101
+- nh3 ==0.3.6 py310hd8a072f_0
+- ninja ==1.13.2 h171cf75_0
+- nlohmann_json ==3.11.3 he02047a_1
+- nodejs ==24.10.0 h8c692ec_1
+- nspr ==4.38 h29cc59b_0
+- nss ==3.118 h445c969_0
+- numba ==0.65.1 py312hd1dde6f_1
+- numcodecs ==0.16.5 py312hf79963d_0
+- numexpr ==2.10.1 mkl_py312h791fadb_2
+- numpy ==2.4.6 py312h33ff503_0
+- obstore ==0.11.0 py312h0ccc70a_0
+- ocl-icd ==2.3.4 hb03c661_1
+- oniguruma ==6.9.10 hb9d3cd8_0
+- openblas ==0.3.33 pthreads_h6ec200e_0
+- opencl-headers ==2025.6.13 hecca717_0
+- opencv ==4.11.0 qt6_py312h56813e9_602
+- openexr ==3.3.5 h09fa569_0
+- openh264 ==2.6.0 h65dd3cf_1
+- openjpeg ==2.5.4 h55fea9a_0
+- openldap ==2.6.10 he970967_0
+- openmpi ==5.0.8 hacb30cd_104
+- openpyxl ==3.1.5 py312h7f6eeab_3
+- openssh ==10.2p1 h20e8eec_0
+- openssl ==3.6.3 h35e630c_0
+- optree ==0.19.1 py312hd9148b4_0
+- orc ==2.1.1 h2271f48_0
+- osqp ==1.1.3 np2py312h0f77346_0
+- pandas ==2.3.3 py312hf79963d_1
+- pandoc ==3.10 ha770c72_0
+- pango ==1.56.3 h9ac818e_1
+- parallelio ==2.6.3 mpi_openmpi_h9c32635_0
+- patch ==2.8 hb03c661_1002
+- patchelf ==0.17.2 h58526e2_0
+- pcre ==8.45 h9c3ff4c_0
+- pcre2 ==10.44 hc749103_2
+- pendulum ==3.2.0 py312h868fb18_2
+- pillow ==12.0.0 py312h898c6c0_1
+- pixman ==0.46.4 h54a6638_1
+- pkg-config ==0.29.2 h4bc722e_1009
+- polars ==1.32.3 default_h3512890_0
+- polars-default ==1.32.3 py39hf521cc8_0
+- poppler ==24.12.0 hd7b24de_2
+- posix_ipc ==1.3.2 py312h4c3975b_0
+- postgresql ==17.6 h021f68a_1
+- proj ==9.5.1 h0054346_0
+- prometheus-cpp ==1.3.0 ha5d0236_0
+- propcache ==0.5.2 py312h8a5da7c_0
+- protobuf ==5.28.3 py312h2ec8cdc_0
+- psutil ==7.2.2 py312h5253ce2_0
+- pthread-stubs ==0.4 hb9d3cd8_1002
+- pugixml ==1.15 h3f63f65_0
+- pulp ==2.8.0 py312hd0750ca_3
+- pulseaudio-client ==17.0 hac146a9_1
+- py-lief ==0.17.6 py312h1289d80_0
+- py-opencv ==4.11.0 qt6_py312hf68ab4e_602
+- py-rattler ==0.25.0 py310h70157a2_1
+- py-rattler-build ==0.67.0 py310hb823017_0
+- pyarrow ==19.0.1 py312h7900ff3_2
+- pyarrow-core ==19.0.1 py312hc195796_2_cpu
+- pycosat ==0.6.6 py312h4c3975b_3
+- pydantic-core ==2.46.4 py312h868fb18_0
+- pyerfa ==2.0.1.5 py310h32771cd_2
+- pygrib ==2.1.8 py312h2f48d4f_0
+- pyhdf ==0.11.6 py312h52fbf50_2
+- pykdtree ==1.4.3 py312h4f23490_2
+- pyogrio ==0.10.0 py312h02b19dd_1
+- pyproj ==3.7.1 py312he630544_0
+- pyqt ==5.15.11 py312h82c0db2_2
+- pyqt5-sip ==12.17.0 py312h1289d80_2
+- pyresample ==1.35.0 py312h1289d80_0
+- pys2index ==0.1.5 py312hbf1ff57_6
+- pyside6 ==6.8.3 py312h91f0f75_0
+- pyspharm ==1.0.9 np2py312hf70805e_1016
+- pysteps ==1.21.1 py312h4f23490_0
+- pytables ==3.10.2 py312h2895ec7_2
+- python ==3.12.13 hd63d673_0_cpython
+- python-eccodes ==2.37.0 py312h4f23490_1
+- python-geotiepoints ==1.9.0 py312h4f23490_1
+- python-gssapi ==1.11.1 py312h7cea900_0
+- python-stratify ==0.4.0 py312h4c3975b_3
+- python-xxhash ==3.7.0 py312h0d868a3_0
+- pytokens ==0.4.1 py312h5253ce2_2
+- pywavelets ==1.9.0 py312h4f23490_2
+- pyyaml ==6.0.3 py312h8a5da7c_1
+- pyzmq ==27.1.0 py312hda471dd_3
+- qdldl-python ==0.1.9.post1 np2py312h0f77346_0
+- qhull ==2020.2 h434a139_5
+- qt-main ==5.15.15 h993ce98_3
+- qt6-main ==6.8.3 h6441bc3_1
+- quaternion ==2024.0.13 py312h4f23490_0
+- r-akima ==0.6_3.6 r44heaba542_1
+- r-backports ==1.5.1 r44h54b55ab_0
+- r-base ==4.4.3 h9c32bc2_0
+- r-bigmemory ==4.6.6 r44h3697838_0
+- r-checkmate ==2.3.3 r44h54b55ab_1
+- r-class ==7.3_23 r44h54b55ab_1
+- r-classint ==0.4_11 r44heaba542_1
+- r-cli ==3.6.6 r44h3697838_0
+- r-climdex.pcic ==1.1_11 r44h3697838_4
+- r-colorspace ==2.1_2 r44h54b55ab_0
+- r-contfrac ==1.1_12 r44h54b55ab_1007
+- r-desolve ==1.42 r44h11cdb10_0
+- r-digest ==0.6.39 r44h3697838_0
+- r-dotcall64 ==1.2 r44heaba542_1
+- r-e1071 ==1.7_17 r44h3697838_0
+- r-ellipsis ==0.3.3 r44h54b55ab_0
+- r-fansi ==1.0.7 r44h54b55ab_0
+- r-farver ==2.1.2 r44h3697838_2
+- r-fields ==17.3 r44heaba542_0
+- r-geomap ==2.5_11 r44h54b55ab_2
+- r-git2r ==0.35.0 r44h4505f3e_0
+- r-glue ==1.8.1 r44h54b55ab_0
+- r-goftest ==1.2_3 r44h54b55ab_4
+- r-isoband ==0.3.0 r44h3697838_0
+- r-jsonlite ==2.0.0 r44h54b55ab_1
+- r-kernsmooth ==2.23_26 r44ha0a88a1_1
+- r-lattice ==0.22_9 r44h54b55ab_0
+- r-lazyeval ==0.2.3 r44h54b55ab_0
+- r-lmom ==3.3 r44heaba542_0
+- r-lmoments ==1.3_2 r44hf1899b2_0
+- r-lubridate ==1.9.5 r44h54b55ab_0
+- r-magrittr ==2.0.5 r44h54b55ab_0
+- r-mapproj ==1.2.12 r44h54b55ab_1
+- r-maps ==3.4.3 r44h54b55ab_1
+- r-mass ==7.3_65 r44h54b55ab_0
+- r-mba ==0.1_3 r44h3697838_0
+- r-ncdf4 ==1.24 r44h241fd4c_0
+- r-pcict ==0.5_4.4 r44h54b55ab_3
+- r-plyr ==1.8.9 r44h3697838_3
+- r-processx ==3.9.0 r44h54b55ab_0
+- r-proxy ==0.4_29 r44h54b55ab_0
+- r-ps ==1.9.3 r44h54b55ab_0
+- r-purrr ==1.2.2 r44h54b55ab_0
+- r-rcpp ==1.1.1_1.1 r44h3697838_0
+- r-rcpparmadillo ==15.4.0_1 r44h3704496_0
+- r-reshape ==0.8.10 r44hc72bb7e_1
+- r-rlang ==1.2.0 r44h3697838_0
+- r-s2 ==1.1.7 r44h4b309dc_0
+- r-s7 ==0.2.2 r44h54b55ab_0
+- r-sf ==1.0_20 r44h4d3cc04_0
+- r-sp ==2.2_1 r44h54b55ab_0
+- r-spam ==2.11_4 r44h2ddecb4_0
+- r-specsverification ==0.5_3 r44h3697838_5
+- r-tibble ==3.3.1 r44h54b55ab_0
+- r-timechange ==0.4.0 r44h3697838_0
+- r-tlmoments ==0.7.5.3 r44h3697838_3
+- r-udunits2 ==0.13.2.2 r44h54b55ab_1
+- r-units ==1.0_1 r44h3697838_0
+- r-utf8 ==1.2.6 r44h54b55ab_1
+- r-uuid ==1.2_2 r44h54b55ab_0
+- r-vctrs ==0.7.3 r44h3697838_0
+- r-wk ==0.9.5 r44h3697838_0
+- r-xfun ==0.59 r44h54b55ab_0
+- r-xml2 ==1.4.0 r44hc6fd541_1
+- r-yaml ==2.3.12 r44h54b55ab_0
+- r-zoo ==1.8_15 r44h54b55ab_0
+- rasterio ==1.4.3 py312h8cae83d_0
+- rattler-build ==0.67.0 ha759004_0
+- rav1e ==0.7.1 h8fae777_3
+- rdma-core ==63.0 h192683f_1
+- re2 ==2024.7.2 h9925aae_2
+- readline ==8.3 h853b02a_0
+- regex ==2026.6.28 py312h4c3975b_0
+- reproc ==14.2.7.post0 hb03c661_1
+- reproc-cpp ==14.2.7.post0 hecca717_1
+- ripgrep ==15.1.0 hdab8a38_0
+- roaring-landmask ==0.10.1 py312h1d298fb_1
+- rpds-py ==2026.6.3 py312h192e038_0
+- ruamel.yaml ==0.18.17 py312h5253ce2_2
+- ruamel.yaml.clib ==0.2.15 py312h5253ce2_1
+- ruff ==0.15.20 h6a952e8_0
+- s2geometry ==0.11.1 he06fccc_3
+- s2n ==1.5.14 h6c98b2b_0
+- safetensors ==0.8.0 py312h868fb18_0
+- scikit-image ==0.26.0 np2py312h4ae17e4_0
+- scikit-learn ==1.8.0 np2py312h3226591_1
+- scipy ==1.17.1 py312h54fa4ab_1
+- scs ==3.2.11 default_py312h250c4f3_1
+- sdl2 ==2.32.54 h3f2d84a_0
+- sdl3 ==3.2.14 he3e324a_0
+- secretstorage ==3.5.0 py312h7900ff3_0
+- sed ==4.10 h19d0853_0
+- setproctitle ==1.3.7 py312h5253ce2_0
+- shap ==0.52.0 cpu_py312h303243a_0
+- shapely ==2.0.7 py312h391bc85_0
+- shellcheck ==0.11.0 ha770c72_1
+- simdjson ==3.12.3 h84d6215_0
+- simplejson ==4.1.1 py312h4c3975b_0
+- sip ==6.10.0 py312h1289d80_1
+- siphash24 ==1.8 py312h4c3975b_2
+- snappy ==1.2.2 h03e3b7b_1
+- spdlog ==1.15.1 hb29a8c4_0
+- sqlalchemy ==2.0.51 py312h5253ce2_0
+- sqlite ==3.53.3 hbc0de68_0
+- statsforecast ==2.0.1 py312h68727a3_0
+- statsmodels ==0.14.6 py312h4f23490_0
+- svt-av1 ==3.0.2 h5888daf_0
+- tbb ==2021.13.0 h8d10470_4
+- tempest-remap ==2.2.0 heeae502_5
+- tensorboard-data-server ==0.7.0 py312h4eba8b5_4
+- tensorflow ==2.18.0 cpu_py312h69ecde4_2
+- tensorflow-base ==2.18.0 cpu_py312h11d59fd_2
+- tensorflow-estimator ==2.18.0 cpu_py312h651dbe2_2
+- tiledb ==2.27.2 hab680f6_2
+- time-machine ==2.19.0 py312h5253ce2_2
+- timezonefinder ==8.2.4 py312h5253ce2_0
+- tk ==8.6.13 noxft_h366c992_103
+- tktable ==2.10 h5a7a40f_8
+- tornado ==6.5.7 py312h4c3975b_0
+- traits ==7.1.0 py312h4c3975b_0
+- trollimage ==1.28.0 py312hf79963d_0
+- tzcode ==2026b h280c20c_0
+- ucc ==1.4.4 h85763d7_1
+- ucx ==1.18.1 h990bcc0_2
+- udunits2 ==2.2.28 h40f5838_3
+- ujson ==5.13.0 py312h8285ef7_0
+- ukkonen ==1.1.0 py312hd9148b4_0
+- unicodedata2 ==17.0.1 py312h4c3975b_0
+- uriparser ==0.9.8 hac33072_0
+- utfcpp ==4.9 ha770c72_0
+- vtk ==9.3.1 qt_py312h71fb23e_216
+- vtk-base ==9.3.1 qt_py312h6cb585f_216
+- vtk-io-ffmpeg ==9.3.1 qt_py312h71fb23e_216
+- watchdog ==6.0.0 py312h20c3967_3
+- wavespectra ==4.5.1 py312h3f74e48_0
+- wayland ==1.25.0 hd6090a7_0
+- wrapt ==2.2.2 py312h4c3975b_0
+- wrf-python ==1.4.2 py312h6a55c13_2
+- x264 ==1!164.3095 h166bdaf_2
+- x265 ==3.5 h924138e_3
+- xcb-util ==0.4.1 h4f16b4b_2
+- xcb-util-cursor ==0.1.6 hb03c661_0
+- xcb-util-image ==0.4.0 hb711507_2
+- xcb-util-keysyms ==0.4.1 hb711507_0
+- xcb-util-renderutil ==0.3.10 hb711507_0
+- xcb-util-wm ==0.4.2 hb711507_0
+- xclip ==0.13 hb9d3cd8_4
+- xerces-c ==3.2.5 h988505b_2
+- xkeyboard-config ==2.48 h280c20c_0
+- xorg-imake ==1.0.11 hecca717_0
+- xorg-libice ==1.1.2 hb9d3cd8_0
+- xorg-libsm ==1.2.6 he73a12e_0
+- xorg-libx11 ==1.8.13 he1eb515_0
+- xorg-libxau ==1.0.12 hb03c661_1
+- xorg-libxaw ==1.0.16 hb9d3cd8_0
+- xorg-libxcomposite ==0.4.7 hb03c661_0
+- xorg-libxcursor ==1.2.3 hb9d3cd8_0
+- xorg-libxdamage ==1.1.6 hb9d3cd8_0
+- xorg-libxdmcp ==1.1.5 hb03c661_1
+- xorg-libxext ==1.3.7 hb03c661_0
+- xorg-libxfixes ==6.0.2 hb03c661_0
+- xorg-libxi ==1.8.3 hb03c661_0
+- xorg-libxinerama ==1.1.6 hecca717_0
+- xorg-libxmu ==1.3.1 hb03c661_0
+- xorg-libxpm ==3.5.19 hb03c661_0
+- xorg-libxrandr ==1.5.5 hb03c661_0
+- xorg-libxrender ==0.9.12 hb9d3cd8_0
+- xorg-libxscrnsaver ==1.2.4 hb9d3cd8_0
+- xorg-libxt ==1.3.1 hb9d3cd8_0
+- xorg-libxtst ==1.2.5 hb9d3cd8_3
+- xorg-libxxf86vm ==1.1.7 hb03c661_0
+- xorg-makedepend ==1.0.9 hecca717_0
+- xorg-xorgproto ==2025.1 hb03c661_0
+- xsel ==1.2.1 hb9d3cd8_6
+- xxhash ==0.8.3 hb47aa4a_0
+- xz ==5.8.3 ha02ee65_0
+- xz-gpl-tools ==5.8.3 ha02ee65_0
+- xz-tools ==5.8.3 hb03c661_0
+- yaml ==0.2.5 h280c20c_3
+- yaml-cpp ==0.8.0 h3f2d84a_0
+- yarl ==1.24.2 py312h8a5da7c_0
+- zeromq ==4.3.5 h387f397_9
+- zfp ==1.0.1 h909a3a2_5
+- zlib ==1.3.2 h25fd6f3_2
+- zlib-ng ==2.2.5 hde8ca8f_1
+- zstandard ==0.25.0 py312h5253ce2_1
+- zstd ==1.5.7 hb78ec9c_6
+- _python_abi3_support ==1.0 hd8ed1ab_2
+- _r-mutex ==1.0.1 anacondar_1
+- _x86_64-microarch-level ==1 4_level1
+- absl-py ==2.5.0 pyhd8ed1ab_0
+- access ==1.1.10.post3 pyhd8ed1ab_0
+- accessible-pygments ==0.0.5 pyhd8ed1ab_1
+- adagio ==0.2.6 pyhd8ed1ab_1
+- adwaita-icon-theme ==49.0 unix_0
+- affine ==2.4.0 pyhd8ed1ab_1
+- aiobotocore ==3.7.0 pyhcf101f3_0
+- aiohappyeyeballs ==2.7.1 pyhd8ed1ab_0
+- aiohttp-cors ==0.8.1 pyhcf101f3_1
+- aioitertools ==0.13.0 pyhd8ed1ab_0
+- aiosignal ==1.4.0 pyhd8ed1ab_0
+- alabaster ==1.0.0 pyhd8ed1ab_1
+- alembic ==1.18.5 pyhcf101f3_0
+- amply ==0.1.7 pyhd8ed1ab_0
+- annotated-doc ==0.0.4 pyhcf101f3_0
+- annotated-types ==0.7.0 pyhd8ed1ab_1
+- anyio ==4.14.1 pyhcf101f3_0
+- anytree ==2.13.0 pyhcf101f3_1
+- appdirs ==1.4.4 pyhd8ed1ab_1
+- apptools ==5.3.1 pyhe01879c_1
+- archspec ==0.2.5 pyhd8ed1ab_0
+- argon2-cffi ==25.1.0 pyhd8ed1ab_0
+- argopy ==1.3.1 pyhd8ed1ab_0
+- arrow ==1.4.0 pyhcf101f3_0
+- arviz ==1.2.0 pyhc364b38_0
+- arviz-base ==1.2.0 pyhd8ed1ab_0
+- arviz-plots ==1.2.0 pyhc364b38_0
+- arviz-stats ==1.2.0 pyh8e99733_0
+- arviz-stats-core ==1.2.0 pyhc364b38_0
+- asteval ==1.0.9 pyhd8ed1ab_0
+- astropy ==8.0.0 pyhd8ed1ab_0
+- astropy-iers-data ==0.2026.6.22.1.23.34 pyhd8ed1ab_0
+- asttokens ==3.0.1 pyhd8ed1ab_0
+- astunparse ==1.6.3 pyhd8ed1ab_3
+- async-lru ==2.3.0 pyhcf101f3_0
+- asyncssh ==2.23.0 pyhd8ed1ab_0
+- attrdict ==2.0.1 py_0
+- attrs ==26.1.0 pyhcf101f3_0
+- autodocsumm ==0.2.15 pyhd8ed1ab_0
+- autopage ==0.6.0 pyhd8ed1ab_0
+- autopep8 ==2.3.2 pyhd8ed1ab_0
+- babel ==2.18.0 pyhcf101f3_1
+- backports ==1.0 pyhd8ed1ab_5
+- backports.tarfile ==1.2.0 pyhcf101f3_2
+- banal ==1.0.6 pyhd8ed1ab_1
+- bargeparse ==0.9.1 pyhd8ed1ab_0
+- base58 ==2.1.1 pyhd8ed1ab_1
+- beautifulsoup4 ==4.15.0 pyha770c72_0
+- bias_correction ==0.4 pyhd8ed1ab_0
+- black ==26.5.1 pyh866005b_0
+- bleach ==6.4.0 pyhcf101f3_0
+- bleach-with-css ==6.4.0 hac0b51c_0
+- blinker ==1.9.0 pyhff2d567_0
+- bokeh ==3.9.1 pyhd8ed1ab_0
+- boltons ==26.0.0 pyhd8ed1ab_0
+- botocore ==1.43.0 pyhd8ed1ab_0
+- bqplot ==0.13.1 pyhcf101f3_0
+- bqscales ==0.3.7 pyhd8ed1ab_1
+- branca ==0.8.2 pyhd8ed1ab_0
+- ca-certificates ==2026.6.17 hbd8a1cb_0
+- cachecontrol ==0.14.4 pyha770c72_0
+- cachecontrol-with-filecache ==0.14.4 pyhd8ed1ab_0
+- cached-property ==1.5.2 hd8ed1ab_1
+- cached_property ==1.5.2 pyha770c72_1
+- cachetools ==7.1.4 pyhd8ed1ab_0
+- cattrs ==26.1.0 pyhcf101f3_1
+- cdsapi ==0.7.7 pyhd8ed1ab_0
+- celluloid ==0.2.0 pyhd8ed1ab_0
+- certifi ==2026.6.17 pyhd8ed1ab_0
+- cf-xarray ==0.11.3 pyhd8ed1ab_0
+- cf_xarray ==0.11.3 pyhd8ed1ab_0
+- cfchecker ==4.1.0 pyhd8ed1ab_1
+- cfgrib ==0.9.15.1 pyhd8ed1ab_0
+- cfgv ==3.5.0 pyhd8ed1ab_0
+- cfunits ==3.3.7 pyhd8ed1ab_1
+- cgen ==2025.1 pyhd8ed1ab_0
+- chardet ==7.4.3 pyhcf101f3_0
+- charset-normalizer ==3.4.7 pyhd8ed1ab_0
+- chart-studio ==1.1.0 pyhd8ed1ab_1
+- click ==8.4.2 pyhc90fa1f_0
+- click-default-group ==1.2.4 pyhd8ed1ab_1
+- click-plugins ==1.1.1.2 pyhd8ed1ab_0
+- cliff ==4.14.0 pyhd8ed1ab_0
+- cligj ==0.7.2 pyhd8ed1ab_2
+- climpred ==2.6.0 pyhd8ed1ab_0
+- cloudpickle ==3.1.2 pyhcf101f3_1
+- cmaps ==2.0.1 pyhd8ed1ab_0
+- cmcrameri ==1.9 pyhd8ed1ab_1
+- cmdline_provenance ==1.1.0 pyhd8ed1ab_1
+- cmocean ==4.0.3 pyhd8ed1ab_1
+- cmweather ==0.3.2 pyhd8ed1ab_1
+- codespell ==2.3.0 pyhd8ed1ab_1
+- colorama ==0.4.6 pyhd8ed1ab_1
+- colorcet ==3.2.1 pyhd8ed1ab_0
+- colorspacious ==1.1.2 pyhecae5ae_1
+- comm ==0.2.3 pyhe01879c_0
+- compliance-checker ==6.1.0 pyhd8ed1ab_0
+- conda-build ==26.5.0 pyh31ec981_0
+- conda-index ==0.12.1 pyhd8ed1ab_0
+- conda-libmamba-solver ==26.6.0 pyhcf101f3_0
+- conda-lock ==4.0.2 pyha191276_0
+- conda-lockfiles ==0.2.0 pyhd8ed1ab_0
+- conda-package-handling ==2.5.0 pyhcf101f3_0
+- conda-package-streaming ==0.13.0 pyhd8ed1ab_0
+- conda-rattler-solver ==0.1.1 pyhcf101f3_0
+- conda-self ==0.2.0 pyhd8ed1ab_0
+- conda-tree ==1.2.0 pyhcf101f3_0
+- config ==0.5.1 pyhd8ed1ab_1
+- configargparse ==1.7.5 pyhcf101f3_0
+- configobj ==5.0.9 pyhd8ed1ab_1
+- constantdict ==2025.3 pyhcf101f3_1
+- contextily ==1.7.0 pyhd8ed1ab_0
+- cpython ==3.12.13 py312hd8ed1ab_0
+- crashtest ==0.4.1 pyhd8ed1ab_1
+- cuda-cccl_linux-64 ==12.4.127 ha770c72_2
+- cuda-cudart-dev_linux-64 ==12.4.127 h85509e4_2
+- cuda-cudart-static_linux-64 ==12.4.127 h85509e4_2
+- cuda-cudart_linux-64 ==12.4.127 h85509e4_2
+- cuda-runtime ==12.4.1 ha804496_0
+- cuda-version ==12.4 h3060b56_3
+- cycler ==0.12.1 pyhcf101f3_2
+- dask ==2026.1.2 pyhcf101f3_1
+- dask-core ==2026.1.2 pyhcf101f3_0
+- dask-glm ==0.3.2 pyhd8ed1ab_0
+- dask-jobqueue ==0.9.0 pyhd8ed1ab_0
+- dask-labextension ==7.0.0 pyhd8ed1ab_1
+- dask-ml ==2025.1.0 pyhd8ed1ab_0
+- dask-xgboost ==0.1.11 pyh9f0ad1d_0
+- dataclasses-json ==0.6.7 pyhcf101f3_2
+- dataset ==1.5.2 pyhd8ed1ab_0
+- datashader ==0.19.1 pyhd8ed1ab_0
+- dateparser ==1.4.1 pyhd8ed1ab_0
+- debtcollector ==3.1.0 pyhd8ed1ab_0
+- decorator ==5.3.1 pyhd8ed1ab_0
+- defusedxml ==0.7.1 pyhd8ed1ab_0
+- deprecated ==1.3.1 pyhd8ed1ab_1
+- deprecation ==2.1.0 pyh9f0ad1d_0
+- descartes ==1.1.0 pyhd8ed1ab_5
+- dill ==0.4.1 pyhcf101f3_0
+- distlib ==0.4.3 pyhcf101f3_0
+- distributed ==2026.1.2 pyhcf101f3_1
+- distro ==1.9.0 pyhd8ed1ab_1
+- doc8 ==2.0.0 pyhd8ed1ab_0
+- docformatter ==1.7.5 pyhd8ed1ab_1
+- docopt-ng ==0.9.0 pyhd8ed1ab_1
+- docrep ==0.3.2 pyh44b312d_0
+- docutils ==0.21.2 pyhd8ed1ab_1
+- dodgy ==0.2.1 py_0
+- dogpile.cache ==1.3.3 pyhd8ed1ab_0
+- donfig ==0.8.1.post1 pyhd8ed1ab_1
+- dreqpy ==1.2.0 pyhd8ed1ab_1
+- earthpy ==0.9.4 pyhd8ed1ab_0
+- ecmwf-api-client ==1.7.0 pyhd8ed1ab_0
+- ecmwf-datastores-client ==0.5.1 pyhd8ed1ab_0
+- emcee ==3.1.6 pyhd8ed1ab_1
+- ensureconda ==1.6.0 pyhcf101f3_0
+- entrypoints ==0.4 pyhd8ed1ab_1
+- envisage ==7.0.4 pyhe01879c_1
+- eofs ==2.0.0 pyhff2d567_0
+- erddapy ==3.3.0 pyhc364b38_0
+- esda ==2.7.1 pyhd8ed1ab_0
+- esgf-pyclient ==0.3.1 pyhd8ed1ab_5
+- esmpy ==8.8.1 pyhecae5ae_0
+- esmvalcore ==2.14.0 pyhc364b38_0
+- esmvaltool ==2.14.0 pyhe136c3f_0
+- esmvaltool-ncl ==2.14.0 hea5a5a1_0
+- esmvaltool-python ==2.14.0 pyhc364b38_0
+- esmvaltool-r ==2.14.0 hea5a5a1_0
+- esmvaltool-sample-data ==0.0.4 pyhd8ed1ab_0
+- et_xmlfile ==2.0.0 pyhd8ed1ab_1
+- evalidate ==2.0.5 pyhe01879c_0
+- exceptiongroup ==1.3.1 pyhd8ed1ab_0
+- execnet ==2.1.2 pyhd8ed1ab_0
+- executing ==2.2.1 pyhd8ed1ab_0
+- f90nml ==1.5 pyhd8ed1ab_0
+- fastprogress ==1.0.3 pyhd8ed1ab_1
+- filelock ==3.29.5 pyhd8ed1ab_0
+- findlibs ==0.1.2 pyhd8ed1ab_0
+- fire ==0.7.1 pyhd8ed1ab_0
+- flake8 ==7.3.0 pyhd8ed1ab_0
+- flake8-polyfill ==1.0.2 pyhd8ed1ab_1
+- flexcache ==0.3 pyhd8ed1ab_1
+- flexparser ==0.4 pyhd8ed1ab_1
+- flox ==0.11.2 pyhd8ed1ab_0
+- folium ==0.20.0 pyhd8ed1ab_0
+- font-ttf-dejavu-sans-mono ==2.37 hab24e00_0
+- font-ttf-inconsolata ==3.0 h77eed37_0
+- font-ttf-source-code-pro ==2.38 h77eed37_0
+- font-ttf-ubuntu ==0.83 h77eed37_3
+- fonts-conda-ecosystem ==1 0
+- fonts-conda-forge ==1 hc364b38_1
+- fortran-language-server ==1.12.0 pyhd8ed1ab_1
+- fqdn ==1.5.1 pyhd8ed1ab_1
+- frozendict ==2.4.7 pyh851646a_2
+- fs ==2.4.16 pyhd8ed1ab_0
+- fsspec ==2026.6.0 pyhd8ed1ab_0
+- fugue ==0.9.7 pyhcf101f3_0
+- future ==1.0.0 pyhd8ed1ab_2
+- gast ==0.7.0 pyhd8ed1ab_0
+- gcm_filters ==0.5.1 pyhd8ed1ab_0
+- gcsfs ==2026.6.0 pyhd8ed1ab_0
+- geocat-comp ==2026.4.0 pyhd8ed1ab_0
+- geocat-viz ==2025.7.0 pyhd8ed1ab_1
+- geographiclib ==2.1 pyhd8ed1ab_0
+- geopandas ==1.1.4 pyhd8ed1ab_0
+- geopandas-base ==1.1.4 pyha770c72_0
+- geoplot ==0.5.1 pyhd8ed1ab_1
+- geopy ==2.4.1 pyhd8ed1ab_2
+- geoviews ==1.14.0 hd8ed1ab_0
+- geoviews-core ==1.14.0 pyha770c72_0
+- giddy ==2.3.8 pyhd8ed1ab_0
+- gitdb ==4.0.12 pyhd8ed1ab_0
+- gitpython ==3.1.50 pyhd8ed1ab_0
+- globus-sdk ==3.65.0 pyhd8ed1ab_0
+- google-api-core ==2.30.3 pyhcf101f3_0
+- google-auth ==2.55.1 pyhcf101f3_0
+- google-auth-oauthlib ==1.4.0 pyhd8ed1ab_0
+- google-cloud-core ==2.5.0 pyhcf101f3_1
+- google-cloud-storage ==3.12.0 pyhcf101f3_0
+- google-cloud-storage-control ==1.10.0 pyhcf101f3_0
+- google-pasta ==0.2.0 pyhd8ed1ab_2
+- google-resumable-media ==2.8.0 pyhd8ed1ab_0
+- googleapis-common-protos ==1.75.0 pyhcf101f3_0
+- googleapis-common-protos-grpc ==1.75.0 pyhcf101f3_0
+- grpc-google-iam-v1 ==0.14.4 pyhcf101f3_0
+- grpcio-status ==1.67.1 pyhd8ed1ab_1
+- h11 ==0.16.0 pyhcf101f3_1
+- h2 ==4.3.0 pyhcf101f3_0
+- h5netcdf ==1.8.1 pyhd8ed1ab_0
+- holidays ==0.99 pyhcf101f3_0
+- holoviews ==1.23.1 pyhd8ed1ab_0
+- hpack ==4.2.0 pyhd8ed1ab_0
+- html5lib ==1.1 pyhd8ed1ab_2
+- httpcore ==1.0.9 pyh29332c3_0
+- httpx ==0.28.1 pyhd8ed1ab_0
+- huggingface_hub ==1.22.0 pyhcf101f3_0
+- humanfriendly ==10.0 pyh707e725_8
+- hupper ==1.12.1 pyhd8ed1ab_1
+- hvplot ==0.12.2 pyhd8ed1ab_0
+- hyperframe ==6.1.0 pyhd8ed1ab_0
+- icclim ==7.1.1 pyhd8ed1ab_0
+- id ==1.6.1 pyhcf101f3_0
+- identify ==2.6.19 pyhd8ed1ab_0
+- idna ==3.18 pyhcf101f3_0
+- imagehash ==4.3.2 pyhd8ed1ab_0
+- imageio ==2.37.0 pyhfb79c49_0
+- imagesize ==2.0.0 pyhd8ed1ab_0
+- immutabledict ==4.3.1 pyhd8ed1ab_0
+- importlib-metadata ==9.0.0 pyhcf101f3_0
+- importlib-resources ==7.1.0 pyhd8ed1ab_0
+- importlib_resources ==7.1.0 pyhd8ed1ab_0
+- inequality ==1.1.2 pyhd8ed1ab_1
+- iniconfig ==2.3.0 pyhd8ed1ab_0
+- intake ==2.0.8 pyhd8ed1ab_0
+- intake-dataframe-catalog ==0.5.1 pyhd8ed1ab_0
+- intake-esgf ==2026.6.4 pyhd8ed1ab_0
+- intake-esm ==2025.12.12 pyhd8ed1ab_0
+- ipdb ==0.13.13 pyhd8ed1ab_1
+- ipydatagrid ==1.4.0 pyhcf101f3_2
+- ipykernel ==6.31.0 pyha191276_0
+- ipympl ==0.10.0 pyhcf101f3_0
+- ipynbname ==2023.2.0.0 pyhd8ed1ab_0
+- ipython ==9.15.0 pyh53cf698_0
+- ipython_pygments_lexers ==1.1.1 pyhd8ed1ab_0
+- ipywidgets ==8.1.8 pyhd8ed1ab_0
+- iris ==3.14.1 pyha770c72_0
+- iris-esmf-regrid ==0.15.0 pyhd8ed1ab_1
+- iris-grib ==0.22.0 pyhd8ed1ab_0
+- iso8601 ==2.1.0 pyhd8ed1ab_1
+- isodate ==0.7.2 pyhd8ed1ab_1
+- isoduration ==20.11.0 pyhd8ed1ab_1
+- isort ==5.13.2 pyhd8ed1ab_1
+- itables ==2.8.1 pyhb6928c1_0
+- itsdangerous ==2.2.0 pyhd8ed1ab_1
+- jaraco.classes ==3.4.0 pyhcf101f3_3
+- jaraco.context ==6.1.2 pyhcf101f3_0
+- jaraco.functools ==4.5.0 pyhcf101f3_0
+- jedi ==0.20.0 pyhcf101f3_0
+- jeepney ==0.9.0 pyhd8ed1ab_0
+- jinja2 ==3.1.6 pyhcf101f3_1
+- jmespath ==1.1.0 pyhcf101f3_1
+- joblib ==1.5.3 pyhd8ed1ab_0
+- jplephem ==2.24 pyha4b2019_1
+- jsmin ==3.0.1 pyhd8ed1ab_1
+- json5 ==0.15.0 pyhd8ed1ab_0
+- jsonpatch ==1.33 pyhd8ed1ab_1
+- jsonpickle ==4.1.2 pyhcf101f3_0
+- jsonpointer ==3.1.1 pyhcf101f3_0
+- jsonschema ==4.26.0 pyhcf101f3_0
+- jsonschema-specifications ==2025.9.1 pyhcf101f3_0
+- jsonschema-with-format-nongpl ==4.26.0 hcf101f3_0
+- jupyter ==1.1.1 pyhd8ed1ab_1
+- jupyter-book ==2.1.5 pyhcf101f3_0
+- jupyter-lsp ==2.3.1 pyhcf101f3_0
+- jupyter-resource-usage ==1.2.1 pyhd8ed1ab_0
+- jupyter-server-proxy ==4.5.0 pyhcf101f3_1
+- jupyter_bokeh ==4.1.0 pyhcf101f3_0
+- jupyter_client ==8.9.1 pyhcf101f3_0
+- jupyter_console ==6.6.3 pyhd8ed1ab_1
+- jupyter_core ==5.9.1 pyhc90fa1f_0
+- jupyter_events ==0.12.1 pyhcf101f3_0
+- jupyter_server ==2.20.0 pyhcf101f3_0
+- jupyter_server_terminals ==0.5.4 pyhcf101f3_0
+- jupyterlab ==4.5.0 pyhd8ed1ab_0
+- jupyterlab_pygments ==0.3.0 pyhd8ed1ab_2
+- jupyterlab_server ==2.28.0 pyhcf101f3_0
+- jupyterlab_widgets ==3.0.16 pyhcf101f3_1
+- keras ==3.11.2 pyh753f3f9_0
+- kerchunk ==0.2.10 pyhd8ed1ab_0
+- kernel-headers_linux-64 ==4.18.0 he073ed8_9
+- keyring ==25.7.0 pyha804496_0
+- keystoneauth1 ==5.15.0 pyhd8ed1ab_0
+- lark ==1.3.1 pyhd8ed1ab_0
+- lat_lon_parser ==1.3.1 pyhd8ed1ab_1
+- latexcodec ==2.0.1 pyh9f0ad1d_0
+- lazy-loader ==0.5 pyhd8ed1ab_0
+- lazy_loader ==0.5 pyhd8ed1ab_0
+- legacy-cgi ==2.6.4 pyhcf101f3_0
+- libgcc-devel_linux-64 ==15.2.0 hcc6f6b0_119
+- libml_dtypes-headers ==0.5.4 h707e725_0
+- libpysal ==4.14.1 pyhd8ed1ab_0
+- libstdcxx-devel_linux-64 ==15.2.0 hd446a21_119
+- lightgbm ==4.6.0 cpu_py_hb6b7976_8
+- lightning-utilities ==0.15.3 pyhd8ed1ab_0
+- lime ==0.2.0.1 pyhd8ed1ab_2
+- linkify-it-py ==2.1.0 pyhcf101f3_0
+- lmfit ==1.3.4 pyhd8ed1ab_0
+- lmoments3 ==1.0.8 pyhd8ed1ab_1
+- locket ==1.0.0 pyhd8ed1ab_0
+- logilab-common ==1.7.3 py_0
+- loguru ==0.7.3 pyh707e725_0
+- magics-python ==1.5.8 pyhd8ed1ab_1
+- mako ==1.3.12 pyhcf101f3_0
+- mapclassify ==2.10.0 pyhd8ed1ab_1
+- mapgenerator ==1.0.7 pyhd8ed1ab_0
+- markdown ==3.10.2 pyhcf101f3_0
+- markdown-it-py ==4.2.0 pyhd8ed1ab_0
+- marshmallow ==3.26.2 pyhd8ed1ab_0
+- matchpy ==0.5.5 pyhd8ed1ab_0
+- matplotlib-inline ==0.2.2 pyhd8ed1ab_0
+- matplotlib-scalebar ==0.9.0 pyhd8ed1ab_0
+- matplotlib-venn ==1.1.2 pyhd8ed1ab_0
+- mccabe ==0.7.0 pyhd8ed1ab_1
+- mda-xdrlib ==0.2.0 pyhd8ed1ab_1
+- mdit-py-plugins ==0.6.1 pyhd8ed1ab_0
+- mdurl ==0.1.2 pyhd8ed1ab_1
+- memory_profiler ==0.61.0 pyhcf101f3_1
+- mercantile ==1.2.1 pyhd8ed1ab_1
+- metpy ==1.7.1 pyhd8ed1ab_0
+- mgwr ==2.2.1 pyhd8ed1ab_1
+- mistune ==3.3.2 pyhcf101f3_0
+- momepy ==1.0.0 pyhd8ed1ab_0
+- more-itertools ==11.1.0 pyhcf101f3_0
+- morphys ==1.0 pyhd8ed1ab_0
+- mpl-scatter-density ==0.8 pyhd8ed1ab_1
+- mplleaflet ==0.0.5 pyhd8ed1ab_5
+- mplotutils ==0.6.0 pyhd8ed1ab_0
+- mpmath ==1.4.1 pyhd8ed1ab_0
+- mscorefonts ==0.0.1 3
+- multipledispatch ==0.6.0 pyhd8ed1ab_1
+- multiset ==2.1.1 py_0
+- multiurl ==0.3.9 pyhd8ed1ab_0
+- munkres ==1.1.4 pyhd8ed1ab_1
+- myproxyclient ==2.2.0 pyhd8ed1ab_0
+- mypy_extensions ==1.1.0 pyha770c72_0
+- namex ==0.1.0 pyhd8ed1ab_0
+- narwhals ==2.23.0 pyhcf101f3_0
+- natsort ==8.4.0 pyhcf101f3_2
+- nb_conda_kernels ==2.5.1 pyh707e725_2
+- nbclient ==0.11.0 pyhd8ed1ab_0
+- nbconvert ==7.17.1 hb502eef_0
+- nbconvert-core ==7.17.1 pyhcf101f3_0
+- nbconvert-pandoc ==7.17.1 h08b4883_0
+- nbdime ==4.0.4 pyhcf101f3_0
+- nbformat ==5.10.4 pyhd8ed1ab_1
+- nbsphinx ==0.9.8 pyhd8ed1ab_0
+- nbval ==0.11.0 pyhd8ed1ab_1
+- nc-time-axis ==1.4.1 pyhd8ed1ab_1
+- ncdata ==0.3.2 pyhd8ed1ab_1
+- nest-asyncio ==1.6.0 pyhd8ed1ab_1
+- nested-lookup ==0.2.25 pyhd8ed1ab_2
+- netaddr ==1.3.0 pyhcf101f3_2
+- networkx ==3.6.1 pyhcf101f3_0
+- neutralocean ==2.4.1 pyhd8ed1ab_0
+- nfoursid ==1.0.2 pyhd8ed1ab_0
+- nodeenv ==1.10.0 pyhd8ed1ab_0
+- notebook ==7.5.0 pyhcf101f3_0
+- notebook-shim ==0.2.4 pyhd8ed1ab_1
+- numpy_groupies ==0.11.3 pyhd8ed1ab_0
+- nvidia-ml-py ==12.575.51 pyhd8ed1ab_0
+- oauthlib ==3.3.1 pyhd8ed1ab_0
+- obspec ==0.1.0 pyhd8ed1ab_0
+- obspec_utils ==0.9.0 pyhd8ed1ab_0
+- odc-geo ==0.5.1 pyhd8ed1ab_0
+- open-radar-data ==0.8.0 pyhd8ed1ab_0
+- openstacksdk ==4.17.0 pyhd8ed1ab_0
+- opt_einsum ==3.4.0 pyhd8ed1ab_1
+- os-service-types ==1.8.2 pyhd8ed1ab_0
+- osc-lib ==4.6.0 pyhd8ed1ab_0
+- oslo.config ==10.5.0 pyhd8ed1ab_0
+- oslo.i18n ==6.8.0 pyhd8ed1ab_0
+- oslo.serialization ==5.10.0 pyhd8ed1ab_0
+- oslo.utils ==10.1.1 pyhd8ed1ab_0
+- overrides ==7.7.0 pyhd8ed1ab_1
+- owslib ==0.36.0 pyhc364b38_0
+- packaging ==26.2 pyhc364b38_0
+- palettable ==3.3.3 pyhd8ed1ab_1
+- pandocfilters ==1.5.0 pyhd8ed1ab_0
+- panel ==1.9.3 pyhd8ed1ab_0
+- panel-core ==1.9.3 pyha770c72_0
+- panel-material-ui ==0.13.0 pyhd8ed1ab_0
+- papermill ==2.7.0 pyhd8ed1ab_0
+- param ==2.4.1 pyhc455866_0
+- parcels ==3.1.0 pyh6fe113f_1
+- parsl ==2026.6.29 pyhcf101f3_0
+- parso ==0.8.7 pyhcf101f3_0
+- partd ==1.4.2 pyhd8ed1ab_0
+- pathlib-abc ==0.5.2 pyh9692d8f_0
+- pathspec ==1.1.1 pyhd8ed1ab_0
+- patsy ==1.0.2 pyhcf101f3_0
+- pbr ==7.0.3 pyhd8ed1ab_0
+- pdbufr ==0.14.2 pyhcf101f3_0
+- pep8-naming ==0.10.0 pyh9f0ad1d_0
+- pexpect ==4.9.0 pyhd8ed1ab_1
+- pint ==0.25.3 pyhc364b38_0
+- pint-xarray ==0.6.1 pyhd8ed1ab_0
+- pip ==26.1.2 pyh8b19718_0
+- pkginfo ==1.12.1.2 pyhd8ed1ab_0
+- platformdirs ==4.10.0 pyhcf101f3_0
+- plotly ==6.8.0 pyhd8ed1ab_0
+- pluggy ==1.6.0 pyhf9edf01_1
+- ply ==3.11 pyhd8ed1ab_3
+- pointpats ==2.5.2 pyhd8ed1ab_0
+- pooch ==1.9.0 pyhd8ed1ab_0
+- poppler-data ==0.4.12 hd8ed1ab_0
+- pre-commit ==4.6.0 pyha770c72_0
+- prettytable ==3.18.0 pyhd8ed1ab_0
+- progressbar2 ==4.5.0 pyhd8ed1ab_1
+- prometheus_client ==0.25.0 pyhd8ed1ab_0
+- prompt-toolkit ==3.0.52 pyha770c72_0
+- prompt_toolkit ==3.0.52 hd8ed1ab_0
+- properscoring ==0.1 pyhd8ed1ab_1
+- prospector ==1.19.0 pyhd8ed1ab_0
+- proto-plus ==1.28.0 pyhcf101f3_0
+- prov ==2.0.0 pyhd3deb0d_0
+- ptyprocess ==0.7.0 pyhd8ed1ab_1
+- pure_eval ==0.2.3 pyhd8ed1ab_1
+- py-cordex ==0.10.5 pyhd8ed1ab_0
+- py-cpuinfo ==9.0.0 pyhd8ed1ab_1
+- py-multihash ==3.0.0 pyhd8ed1ab_0
+- py-xgboost ==3.3.0 cpu_pyh718b53a_0
+- py2vega ==0.7.0 pyhd8ed1ab_0
+- pyaml ==26.2.1 pyhcf101f3_1
+- pyasn1 ==0.6.3 pyhcf101f3_0
+- pyasn1-modules ==0.4.2 pyhd8ed1ab_0
+- pybind11-abi ==4 hd8ed1ab_3
+- pybtex ==0.26.1 pyhcf101f3_0
+- pycodestyle ==2.14.0 pyhd8ed1ab_0
+- pycparser ==3.0 pyhcf101f3_0
+- pyct ==0.6.0 pyhd8ed1ab_0
+- pydantic ==2.13.4 pyhcf101f3_0
+- pydap ==3.5.10 pyhc455866_0
+- pydata-sphinx-theme ==0.19.0 pyhcf101f3_0
+- pydocstyle ==6.3.0 pyhd8ed1ab_1
+- pydot ==4.0.1 pyhcf101f3_2
+- pyextremes ==2.5.0 pyhd8ed1ab_0
+- pyface ==8.0.0 pyhd8ed1ab_2
+- pyfive ==1.1.2 pyhd8ed1ab_0
+- pyflakes ==3.4.0 pyhd8ed1ab_0
+- pygam ==0.12.0 pyhd8ed1ab_0
+- pygeoif ==1.6.0 pyhd8ed1ab_0
+- pygments ==2.20.0 pyhd8ed1ab_0
+- pygmt ==0.18.0 pyhcf101f3_0
+- pyjwt ==2.13.0 pyhcf101f3_0
+- pylint ==4.0.6 pyhcf101f3_0
+- pylint-celery ==0.3 py_1
+- pylint-django ==2.7.0 pyhd8ed1ab_0
+- pylint-flask ==0.6 py_0
+- pylint-plugin-utils ==0.9.0 pyhd8ed1ab_0
+- pymannkendall ==1.4.3 pyha21a80b_0
+- pymbolic ==2025.1 pyhc455866_0
+- pynvml ==12.0.0 pyhd8ed1ab_0
+- pyod ==3.6.1 pyhd8ed1ab_0
+- pyopenssl ==26.3.0 pyhcf101f3_0
+- pyorbital ==1.12.1 pyhd8ed1ab_0
+- pyparsing ==3.3.2 pyhcf101f3_0
+- pyperclip ==1.11.0 pyha804496_0
+- pyproject_hooks ==1.2.0 pyhd8ed1ab_1
+- pyroma ==5.0.1 pyhd8ed1ab_0
+- pysal ==25.7 pyhd8ed1ab_0
+- pyshp ==3.1.4 pyhcf101f3_0
+- pysocks ==1.7.1 pyha55dd90_7
+- pyspectral ==0.14.3 pyhd8ed1ab_0
+- pystac ==1.14.3 pyhd8ed1ab_0
+- pystac-client ==0.9.0 pyhd8ed1ab_0
+- pytest ==9.1.1 pyhc364b38_2
+- pytest-cov ==7.1.0 pyhcf101f3_0
+- pytest-env ==1.6.0 pyhd8ed1ab_0
+- pytest-html ==4.2.0 pyhd8ed1ab_0
+- pytest-metadata ==3.1.1 pyhd8ed1ab_1
+- pytest-mock ==3.15.1 pyhd8ed1ab_0
+- pytest-subtests ==0.15.0 pyhd8ed1ab_0
+- pytest-xdist ==3.8.0 pyhd8ed1ab_0
+- python-build ==1.5.0 pyhc364b38_0
+- python-cdo ==1.6.1 pyh332efcf_1
+- python-cinderclient ==9.9.0 pyh332efcf_0
+- python-dateutil ==2.9.0.post0 pyhe01879c_2
+- python-dotenv ==1.2.2 pyhcf101f3_0
+- python-fastjsonschema ==2.21.2 pyhe01879c_0
+- python-flatbuffers ==25.9.23 pyh1e1bc0e_0
+- python-gil ==3.12.13 hd8ed1ab_0
+- python-graphviz ==0.21 pyhbacfb6d_0
+- python-installer ==1.0.1 pyh332efcf_0
+- python-json-logger ==4.1.0 pyhd8ed1ab_0
+- python-keystoneclient ==5.8.0 pyh332efcf_0
+- python-libarchive-c ==5.3 pyhe01879c_1
+- python-magic ==0.4.27 pyhd7f29a5_7
+- python-novaclient ==18.13.0 pyh332efcf_0
+- python-openstackclient ==9.0.0 pyh332efcf_0
+- python-swiftclient ==4.10.0 pyh332efcf_0
+- python-tzdata ==2026.2 pyhd8ed1ab_0
+- python-utils ==4.0.0 pyh332efcf_0
+- python_abi ==3.12 8_cp312
+- pytools ==2026.1.1 pyhd8ed1ab_0
+- pytorch-lightning ==2.5.2 pyh2a12c56_0
+- pytz ==2026.2 pyhcf101f3_0
+- pyu2f ==0.1.5 pyhd8ed1ab_1
+- pyviz_comms ==3.0.6 pyhd8ed1ab_0
+- pyxdg ==0.28 pyhd8ed1ab_0
+- quantecon ==0.11.2 pyhd8ed1ab_0
+- r-abind ==1.4_8 r44hc72bb7e_1
+- r-bigmemory.sri ==0.1.8 r44hc72bb7e_2
+- r-callr ==3.7.6 r44hc72bb7e_2
+- r-climprojdiags ==0.3.5 r44hc72bb7e_0
+- r-codetools ==0.2_20 r44hc72bb7e_2
+- r-cpp11 ==0.5.5 r44h785f33e_0
+- r-crayon ==1.5.3 r44hc72bb7e_2
+- r-cyclocomp ==1.1.2 r44hc72bb7e_0
+- r-dbi ==1.3.0 r44hc72bb7e_0
+- r-desc ==1.4.3 r44hc72bb7e_2
+- r-docopt ==0.7.2 r44hc72bb7e_1
+- r-doparallel ==1.0.17 r44hc72bb7e_4
+- r-elliptic ==1.5_1 r44hc72bb7e_0
+- r-evaluate ==1.0.5 r44hc72bb7e_1
+- r-foreach ==1.5.2 r44hc72bb7e_4
+- r-functional ==0.7 r44hc72bb7e_0
+- r-generics ==0.1.4 r44hc72bb7e_1
+- r-geomapdata ==2.0_2 r44hc72bb7e_2
+- r-ggplot2 ==4.0.3 r44h785f33e_0
+- r-gridextra ==2.3.1 r44hc72bb7e_0
+- r-gtable ==0.3.6 r44hc72bb7e_1
+- r-highr ==0.12 r44hc72bb7e_0
+- r-hypergeo ==1.2_14 r44hc72bb7e_1
+- r-iterators ==1.0.14 r44hc72bb7e_4
+- r-knitr ==1.51 r44hc72bb7e_0
+- r-labeling ==0.4.3 r44hc72bb7e_2
+- r-lifecycle ==1.0.5 r44hc72bb7e_0
+- r-lintr ==3.1.2 r44hc72bb7e_1
+- r-lisp ==0.2 r44hc72bb7e_0
+- r-lmomco ==2.5.5 r44hc72bb7e_0
+- r-logging ==0.10_111 r44hc72bb7e_0
+- r-multiapply ==2.1.5 r44hc72bb7e_1
+- r-munsell ==0.5.1 r44hc72bb7e_2
+- r-nbclust ==3.0.1 r44hc72bb7e_4
+- r-ncdf4.helpers ==0.3_7 r44hc72bb7e_1
+- r-pillar ==1.11.1 r44hc72bb7e_0
+- r-pkgconfig ==2.0.3 r44hc72bb7e_5
+- r-r.cache ==0.17.0 r44hc72bb7e_1
+- r-r.methodss3 ==1.8.2 r44hc72bb7e_4
+- r-r.oo ==1.27.1 r44hc72bb7e_1
+- r-r.utils ==2.13.0 r44hc72bb7e_1
+- r-r6 ==2.6.1 r44hc72bb7e_1
+- r-rcolorbrewer ==1.1_3 r44h785f33e_4
+- r-rematch2 ==2.1.2 r44hc72bb7e_5
+- r-remotes ==2.5.0 r44hc72bb7e_2
+- r-rex ==1.2.2 r44hc72bb7e_0
+- r-rpmg ==2.2_7 r44hc72bb7e_2
+- r-rprojroot ==2.1.1 r44hc72bb7e_1
+- r-s2dverification ==2.10.3 r44hc72bb7e_4
+- r-scales ==1.4.0 r44hc72bb7e_1
+- r-snow ==0.4_4 r44hc72bb7e_4
+- r-spei ==1.8.1 r44hc72bb7e_3
+- r-styler ==1.10.3 r44hc72bb7e_2
+- r-viridislite ==0.4.3 r44hc72bb7e_0
+- r-withr ==3.0.3 r44hc72bb7e_0
+- r-xmlparsedata ==1.0.5 r44hc72bb7e_4
+- rasterstats ==0.21.0 pyhcf101f3_0
+- rdflib ==7.6.0 pyhcf101f3_0
+- readme_renderer ==45.0 pyhcf101f3_1
+- rechunker ==0.5.2 pyhd8ed1ab_2
+- referencing ==0.37.0 pyhcf101f3_0
+- regional-mom6 ==1.0.1 pyhd8ed1ab_0
+- regionmask ==0.13.0 pyhd8ed1ab_0
+- requests ==2.34.2 pyhcf101f3_0
+- requests-cache ==1.3.3 pyhd8ed1ab_0
+- requests-oauthlib ==2.0.0 pyhd8ed1ab_1
+- requests-toolbelt ==1.0.0 pyhd8ed1ab_1
+- requestsexceptions ==1.4.0 py_0
+- requirements-detector ==1.4.0 pyhd8ed1ab_0
+- restructuredtext_lint ==2.0.2 pyhd8ed1ab_0
+- retrying ==1.4.2 pyhe01879c_0
+- rfc3339-validator ==0.1.4 pyhd8ed1ab_1
+- rfc3986 ==2.0.0 pyhd8ed1ab_1
+- rfc3986-validator ==0.1.1 pyh9f0ad1d_0
+- rfc3987-syntax ==1.1.0 pyhe01879c_1
+- rich ==15.0.0 pyhcf101f3_0
+- rich-argparse ==1.8.0 pyhd8ed1ab_0
+- rioxarray ==0.20.0 pyhd8ed1ab_1
+- roman-numerals ==4.1.0 pyhd8ed1ab_0
+- rsa ==4.9.1 pyhd8ed1ab_0
+- rtree ==1.4.1 pyh11ca60a_0
+- s3fs ==2026.6.0 pyhd8ed1ab_0
+- satpy ==0.60.0 pyhd8ed1ab_0
+- scores ==2.5.0 pyhd8ed1ab_0
+- seaborn ==0.13.2 hd8ed1ab_3
+- seaborn-base ==0.13.2 pyhd8ed1ab_3
+- seawater ==3.3.5 pyhd8ed1ab_1
+- segregation ==2.5.5 pyhd8ed1ab_0
+- semver ==3.0.4 pyhcf101f3_1
+- send2trash ==2.1.0 pyha191276_1
+- setoptconf-tmp ==0.3.1 pyhd8ed1ab_0
+- setuptools ==82.0.1 pyh332efcf_0
+- setuptools-scm ==10.2.0 pyhcf101f3_0
+- setuptools_scm ==10.2.0 he0c3440_0
+- sh ==2.2.4 pyh707e725_0
+- shellingham ==1.5.4 pyhd8ed1ab_2
+- simpervisor ==1.0.0 pyhd8ed1ab_1
+- siphon ==0.10.0 pyhd8ed1ab_1
+- six ==1.17.0 pyhe01879c_1
+- slicer ==0.0.8 pyhd8ed1ab_0
+- smmap ==5.0.3 pyhcf101f3_1
+- sniffio ==1.3.1 pyhd8ed1ab_2
+- snowballstemmer ==3.1.1 pyhd8ed1ab_0
+- snuggs ==1.4.7 pyhd8ed1ab_2
+- sortedcontainers ==2.4.0 pyhd8ed1ab_1
+- soupsieve ==2.8.4 pyhd8ed1ab_0
+- spaghetti ==1.7.6 pyhd8ed1ab_1
+- sparse ==0.19.0 pyhc364b38_0
+- spglm ==1.1.0 pyhd8ed1ab_2
+- sphinx ==9.1.0 pyhd8ed1ab_0
+- sphinxcontrib-applehelp ==2.0.0 pyhd8ed1ab_1
+- sphinxcontrib-devhelp ==2.0.0 pyhd8ed1ab_1
+- sphinxcontrib-htmlhelp ==2.1.0 pyhd8ed1ab_1
+- sphinxcontrib-jsmath ==1.0.1 pyhd8ed1ab_1
+- sphinxcontrib-qthelp ==2.0.0 pyhd8ed1ab_1
+- sphinxcontrib-serializinghtml ==2.0.0 pyhd8ed1ab_0
+- spint ==1.1.0 pyhd8ed1ab_0
+- splot ==1.1.7 pyhd8ed1ab_1
+- spopt ==0.7.0 pyhd8ed1ab_0
+- spreg ==1.9.0 pyhd8ed1ab_0
+- spvcm ==0.3.0 pyhd8ed1ab_2
+- spyder-kernels ==3.1.5 unix_pyh707e725_0
+- stack_data ==0.6.3 pyhd8ed1ab_1
+- stevedore ==5.9.0 pyhd8ed1ab_0
+- sympy ==1.14.0 pyh2585a3b_106
+- sysroot_linux-64 ==2.28 h4ee821c_9
+- tabulate ==0.10.0 pyhcf101f3_0
+- tblib ==3.2.2 pyhcf101f3_0
+- tenacity ==9.1.4 pyhcf101f3_0
+- tensorboard ==2.18.0 pyhd8ed1ab_1
+- tensorboardx ==2.6.2.2 pyhd8ed1ab_1
+- termcolor ==3.3.0 pyhd8ed1ab_0
+- terminado ==0.18.1 pyhc90fa1f_1
+- threadpoolctl ==3.6.0 pyhecae5ae_0
+- tifffile ==2025.12.12 pyhd8ed1ab_0
+- tintx ==2022.12.2 pyhd8ed1ab_0
+- tinycss2 ==1.4.0 pyhd8ed1ab_0
+- tobler ==0.14.0 pyhd8ed1ab_0
+- toml ==0.10.2 pyhcf101f3_3
+- tomli ==2.4.1 pyhcf101f3_0
+- tomli-w ==1.2.0 pyhd8ed1ab_0
+- tomlkit ==0.15.0 pyha770c72_0
+- toolz ==1.1.0 pyhd8ed1ab_1
+- torchmetrics ==1.9.0 pyhd8ed1ab_0
+- tqdm ==4.68.3 pyh8f84b5b_0
+- traitlets ==5.15.1 pyhcf101f3_0
+- traitsui ==8.0.0 pyhd8ed1ab_1
+- traittypes ==0.2.3 pyh332efcf_0
+- trajan ==0.11.0 pyhd8ed1ab_0
+- triad ==1.0.2 pyhcf101f3_0
+- trollsift ==1.0.1 pyhd8ed1ab_0
+- trove-classifiers ==2026.6.1.19 pyhcf101f3_0
+- truststore ==0.10.4 pyhcf101f3_0
+- twine ==6.2.0 pyhcf101f3_0
+- typeguard ==4.5.2 pyhcf101f3_0
+- typer ==0.26.8 pyhcf101f3_0
+- typing-extensions ==4.16.0 h69aa097_0
+- typing-inspection ==0.4.2 pyhcf101f3_2
+- typing_extensions ==4.16.0 pyhcf101f3_0
+- typing_inspect ==0.9.0 pyhd8ed1ab_1
+- typing_utils ==0.1.0 pyhd8ed1ab_1
+- tzdata ==2025c hc9c84f9_1
+- tzlocal ==5.4.4 pyh8f84b5b_0
+- u8darts ==0.45.0 pyhd8ed1ab_0
+- u8darts-all ==0.45.0 pyhd8ed1ab_0
+- uc-micro-py ==2.0.0 pyhcf101f3_0
+- ultraplot ==2.3.0 pyhd8ed1ab_0
+- uncertainties ==3.2.3 pyhd8ed1ab_0
+- uncompresspy ==0.4.1 pyhd8ed1ab_0
+- unearth ==0.18.2 pyhd8ed1ab_0
+- universal-pathlib ==0.3.10 hd8ed1ab_0
+- universal_pathlib ==0.3.10 pyhd8ed1ab_0
+- untokenize ==0.1.1 pyhcf101f3_3
+- uri-template ==1.3.0 pyhd8ed1ab_1
+- uritools ==6.1.2 pyhd8ed1ab_0
+- url-normalize ==3.0.0 pyhd8ed1ab_0
+- urllib3 ==2.5.0 pyhd8ed1ab_0
+- utilsforecast ==0.2.16 pyhd8ed1ab_0
+- validators ==0.35.0 pyhd8ed1ab_0
+- varint ==1.0.2 pyhd8ed1ab_1
+- vcs_versioning ==2.2.2 pyhcf101f3_0
+- versioneer ==0.29 pyhd8ed1ab_0
+- virtualenv ==20.39.0 pyhcf101f3_0
+- virtualizarr ==2.7.0 pyhd8ed1ab_0
+- watermark ==2.6.0 pyhcf101f3_0
+- wayland-protocols ==1.49 hd8ed1ab_0
+- wcwidth ==0.8.2 pyhd8ed1ab_0
+- webcolors ==25.10.0 pyhd8ed1ab_0
+- webencodings ==0.5.1 pyhd8ed1ab_3
+- webob ==1.8.10 pyhd8ed1ab_0
+- websocket-client ==1.9.0 pyhd8ed1ab_0
+- werkzeug ==3.1.8 pyhcf101f3_0
+- wheel ==0.47.0 pyhd8ed1ab_0
+- widgetsnbextension ==4.0.15 pyhd8ed1ab_0
+- windspharm ==2.0.0 pyhd8ed1ab_1
+- wradlib ==2.8.0 pyhd8ed1ab_0
+- wslink ==2.5.7 pyhd8ed1ab_0
+- wurlitzer ==3.1.1 pyhd8ed1ab_1
+- xarray ==2026.1.0 pyhcf101f3_0
+- xarray-einstats ==0.10.0 pyhd8ed1ab_0
+- xarray-spatial ==0.10.15 pyhd8ed1ab_0
+- xarraymannkendall ==1.4.5 pyhd8ed1ab_0
+- xcdat ==0.11.2 pyhd8ed1ab_1
+- xclim ==0.61.1 pyhd8ed1ab_0
+- xesmf ==0.9.2 pyhd8ed1ab_0
+- xgboost ==3.3.0 cpu_pyhb39878e_0
+- xgcm ==0.9.0 pyhd8ed1ab_0
+- xhistogram ==0.3.2 pyhd8ed1ab_0
+- xlsxwriter ==3.2.9 pyhd8ed1ab_0
+- xmip ==0.7.2 pyhd8ed1ab_1
+- xmitgcm ==0.5.2 pyhd8ed1ab_1
+- xmltodict ==1.0.4 pyhcf101f3_0
+- xmovie ==0.3.1 pyhd8ed1ab_0
+- xradar ==0.12.0 pyhd8ed1ab_0
+- xrft ==1.0.2 pyhd8ed1ab_0
+- xsdba ==0.7.0 pyhd8ed1ab_0
+- xskillscore ==0.0.29 pyhd8ed1ab_0
+- xwrf ==0.0.5 pyhd8ed1ab_0
+- xyzservices ==2026.3.0 pyhd8ed1ab_0
+- yamale ==6.1.0 pyhd8ed1ab_0
+- yamllint ==1.35.1 pyhd8ed1ab_1
+- yapf ==0.43.0 pyhd8ed1ab_1
+- zarr ==3.2.1 pyhc364b38_0
+- zict ==3.0.0 pyhd8ed1ab_1
+- zipp ==4.1.0 pyhcf101f3_0
+- pytorch ==2.5.1 py3.12_cuda12.4_cudnn9.1.0_0
+- pytorch-cuda ==12.4 hc786d27_7
+- torchtriton ==3.1.0 py312
+- pytorch-mutex ==1.0 cuda
+- ucx-py ==0.45.0 py312_250806_d53bdda0
+- pip
+- pip:
+  - pyld==3.1.0
+  - pycnv==0.5.0
+  - wget==3.2
+  - lavavu-osmesa==1.9.10
+  - cmip7-repack==1.1.0
+  - py360convert==1.0.4
+  - esgvoc==4.2.0
+  - nci-ipynb==2023.11.0.3
+  - frisky==0.1.1
+  - lavavu==1.9.10
+  - accessvis==1.1.4
+  - railroad-diagrams==3.0.1
+  - sqlmodel==0.0.39
+  - cc-plugin-wcrp==2.3.2
+  - cmip7-data-request-api==1.4

--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1298,6 +1298,7 @@ dependencies:
 - rechunker ==0.5.2 pyhd8ed1ab_2
 - referencing ==0.37.0 pyhcf101f3_0
 - regional-mom6 ==1.0.1 pyhd8ed1ab_0
+- regionate ==0.5.5 pyhd8ed1ab_0
 - regionmask ==0.13.0 pyhd8ed1ab_0
 - requests ==2.34.2 pyhcf101f3_0
 - requests-cache ==1.3.3 pyhd8ed1ab_0
@@ -1323,6 +1324,7 @@ dependencies:
 - seaborn ==0.13.2 hd8ed1ab_3
 - seaborn-base ==0.13.2 pyhd8ed1ab_3
 - seawater ==3.3.5 pyhd8ed1ab_1
+- sectionate ==0.3.3 pyhd8ed1ab_0
 - segregation ==2.5.5 pyhd8ed1ab_0
 - semver ==3.0.4 pyhcf101f3_1
 - send2trash ==2.1.0 pyha191276_1
@@ -1438,6 +1440,7 @@ dependencies:
 - xarray-einstats ==0.10.0 pyhd8ed1ab_0
 - xarray-spatial ==0.10.15 pyhd8ed1ab_0
 - xarraymannkendall ==1.4.5 pyhd8ed1ab_0
+- xbudget ==0.6.3 pyhd8ed1ab_0
 - xcdat ==0.11.2 pyhd8ed1ab_1
 - xclim ==0.61.1 pyhd8ed1ab_0
 - xesmf ==0.9.2 pyhd8ed1ab_0
@@ -1453,6 +1456,8 @@ dependencies:
 - xrft ==1.0.2 pyhd8ed1ab_0
 - xsdba ==0.7.0 pyhd8ed1ab_0
 - xskillscore ==0.0.29 pyhd8ed1ab_0
+- xwmb ==0.6.0 pyhd8ed1ab_0
+- xwmt ==0.2.0 pyhd8ed1ab_0
 - xwrf ==0.0.5 pyhd8ed1ab_0
 - xyzservices ==2026.3.0 pyhd8ed1ab_0
 - yamale ==6.1.0 pyhd8ed1ab_0

--- a/environments/analysis3/pixi.lock
+++ b/environments/analysis3/pixi.lock
@@ -1304,6 +1304,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rechunker-0.5.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/regional-mom6-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/regionate-0.5.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/regionmask-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.3-pyhd8ed1ab_0.conda
@@ -1329,6 +1330,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seawater-3.3.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sectionate-0.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/segregation-2.5.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
@@ -1444,6 +1446,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarraymannkendall-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xbudget-0.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xcdat-0.11.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xclim-0.61.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xesmf-0.9.2-pyhd8ed1ab_0.conda
@@ -1459,6 +1462,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xrft-1.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdba-0.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xskillscore-0.0.29-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xwmb-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xwmt-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xwrf-0.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamale-6.1.0-pyhd8ed1ab_0.conda
@@ -2789,6 +2794,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rechunker-0.5.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/regional-mom6-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/regionate-0.5.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/regionmask-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.3-pyhd8ed1ab_0.conda
@@ -2814,6 +2820,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seawater-3.3.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sectionate-0.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/segregation-2.5.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
@@ -2929,6 +2936,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarraymannkendall-1.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xbudget-0.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xcdat-0.11.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xclim-0.61.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xesmf-0.9.2-pyhd8ed1ab_0.conda
@@ -2944,6 +2952,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xrft-1.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdba-0.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xskillscore-0.0.29-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xwmb-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xwmt-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xwrf-0.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamale-6.1.0-pyhd8ed1ab_0.conda
@@ -24442,6 +24452,23 @@ packages:
   run_exports: {}
   size: 80652
   timestamp: 1747879421626
+- conda: https://conda.anaconda.org/conda-forge/noarch/regionate-0.5.5-pyhd8ed1ab_0.conda
+  sha256: 81529460cceb81c1597303397f14ac4db09a2bfa08419699dcf131fb8167840d
+  md5: 12f7b53d2b82182f604a1bb2f5a91331
+  depends:
+  - contourpy
+  - geopandas
+  - pyproj
+  - python >=3.11
+  - regionmask
+  - sectionate >=0.3.3
+  license: GPL-3.0-only
+  license_family: GPL
+  purls:
+  - pkg:pypi/regionate?source=hash-mapping
+  run_exports: {}
+  size: 30463
+  timestamp: 1771717035508
 - conda: https://conda.anaconda.org/conda-forge/noarch/regionmask-0.13.0-pyhd8ed1ab_0.conda
   sha256: ff5398b5d167690c3f20ab765455cdd6da4590167ae7a71424ad21bf158f193f
   md5: bcf505f94f8cc1d21475901526b33ab5
@@ -24824,6 +24851,24 @@ packages:
   run_exports: {}
   size: 27160
   timestamp: 1734958954564
+- conda: https://conda.anaconda.org/conda-forge/noarch/sectionate-0.3.3-pyhd8ed1ab_0.conda
+  sha256: f08c15a682ffae43f61bd175e2a759df17fb79d2fdbc0e376b4ecde55bfab788
+  md5: cf7745a7dece2c2a67afee810189a686
+  depends:
+  - dask
+  - numba
+  - numpy
+  - python >=3.11
+  - scipy
+  - xarray
+  - xgcm >=0.9.0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls:
+  - pkg:pypi/sectionate?source=hash-mapping
+  run_exports: {}
+  size: 37054
+  timestamp: 1771695058220
 - conda: https://conda.anaconda.org/conda-forge/noarch/segregation-2.5.5-pyhd8ed1ab_0.conda
   sha256: d3f74bb2ee712b7e373f5806caee795b55e0febe82dae9e5ff6eeba2d7cffbb8
   md5: 40449f39a0113ba929f5b880424439c6
@@ -26573,6 +26618,21 @@ packages:
   run_exports: {}
   size: 12623
   timestamp: 1678994700493
+- conda: https://conda.anaconda.org/conda-forge/noarch/xbudget-0.6.3-pyhd8ed1ab_0.conda
+  sha256: cda0d70e61192c3ee1ca78cf592d69ac7a2fef3b5607f271fb0b19a29ecb1374
+  md5: e63d389a3ef3ea3a74b7070a995ca26a
+  depends:
+  - numpy
+  - python >=3.11
+  - xarray
+  - xgcm >=0.9.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/xbudget?source=hash-mapping
+  run_exports: {}
+  size: 22865
+  timestamp: 1771974611797
 - conda: https://conda.anaconda.org/conda-forge/noarch/xcdat-0.11.2-pyhd8ed1ab_1.conda
   sha256: 115b777cdea35721f693b201b4ee8ee4da9715d89d380fad9d29cffd6cbf8cb2
   md5: a8213fa2bc9b5f5f94d84e432eeac4f0
@@ -26870,6 +26930,41 @@ packages:
   run_exports: {}
   size: 90065
   timestamp: 1771437438532
+- conda: https://conda.anaconda.org/conda-forge/noarch/xwmb-0.6.0-pyhd8ed1ab_0.conda
+  sha256: a2b96cca4489d5724cfa9cad256be1cb0de10c1bed32e3289e3a1be49036d9b9
+  md5: 4581dd2bb5a6a41e2e5729a113451d55
+  depends:
+  - python >=3.11
+  - regionate >=0.5.5
+  - xwmt >=0.2.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/xwmb?source=hash-mapping
+  run_exports: {}
+  size: 17338
+  timestamp: 1771988903865
+- conda: https://conda.anaconda.org/conda-forge/noarch/xwmt-0.2.0-pyhd8ed1ab_0.conda
+  sha256: b544fa84673f989daaf8bd48432a8b3772a8027a455db78123bf1cd55c8f6665
+  md5: d9e6dc948c547cfacb395e9d8d73cefa
+  depends:
+  - bottleneck
+  - gsw
+  - numba
+  - numpy
+  - pandas
+  - python >=3.11
+  - xarray
+  - xbudget >=0.6.0
+  - xgcm >=0.9.0
+  - xhistogram
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/xwmt?source=hash-mapping
+  run_exports: {}
+  size: 22988
+  timestamp: 1771985441915
 - conda: https://conda.anaconda.org/conda-forge/noarch/xwrf-0.0.5-pyhd8ed1ab_0.conda
   sha256: 6cb243fc037937e0247ee6009ceb51a505039ef0f3711dfa210602f3169c2691
   md5: 82b882714504332491fa593d11129452

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -20,7 +20,9 @@ analysis3 = ["default"]
 
 [tasks]
 ensure-locked = { cmd = "pixi lock --check", description = "Ensure the lockfile is up to date" }
-rebuild-env = { cmd = "pixi workspace export conda-environment --from-lockfile environment.yml", description = "Rebuild environment.yml from lock file", depends-on = ["ensure-locked"] }
+rebuild-env = { cmd = "pixi workspace export conda-environment --name analysis3 --from-lockfile environment.yml", description = "Rebuild environment.yml from lock file", depends-on = [
+  "ensure-locked",
+] }
 check-broken-packages = { cmd = "python3 check_broken_packages.py", description = "Check that broken-labelled packages in pixi.lock match pixi.toml declarations" }
 
 [dependencies]

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -338,6 +338,7 @@ python-swiftclient = ">=4.10.0,<5"
 python-openstackclient = ">=9.0.0,<10"
 parsl = ">=2026.3.16,<2027"
 regional-mom6 = ">=1.0.1,<2"
+xwmb = "*"
 
 [pypi-dependencies]
 lavavu = "==1.9.10"

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -20,7 +20,7 @@ analysis3 = ["default"]
 
 [tasks]
 ensure-locked = { cmd = "pixi lock --check", description = "Ensure the lockfile is up to date" }
-rebuild-env = { cmd = "pixi workspace export conda-environment --from-lock-file", description = "Rebuild environment.yml from lock file", depends-on = ["ensure-locked"] }
+rebuild-env = { cmd = "pixi workspace export conda-environment --from-lockfile environment.yml", description = "Rebuild environment.yml from lock file", depends-on = ["ensure-locked"] }
 check-broken-packages = { cmd = "python3 check_broken_packages.py", description = "Check that broken-labelled packages in pixi.lock match pixi.toml declarations" }
 
 [dependencies]

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -20,7 +20,7 @@ analysis3 = ["default"]
 
 [tasks]
 ensure-locked = { cmd = "pixi lock --check", description = "Ensure the lockfile is up to date" }
-rebuild-env = { cmd = "pixi workspace export conda-environment --name analysis3 --from-lockfile environment.yml", description = "Rebuild environment.yml from lock file", depends-on = [
+rebuild-env = { cmd = "pixi workspace export conda-environment --platform linux-64 --name analysis3 --from-lock-file | grep -v '^- _' > environment.yml", description = "Rebuild environment.yml from lock file, dropping internal _-prefixed packages the solver re-adds transitively", depends-on = [
   "ensure-locked",
 ] }
 check-broken-packages = { cmd = "python3 check_broken_packages.py", description = "Check that broken-labelled packages in pixi.lock match pixi.toml declarations" }


### PR DESCRIPTION
Add xwmb #445

Also:

This pull request makes a minor update to the `pixi.toml` file for the `analysis3` environment, adjusting the command used to rebuild the environment file.

- Task command update:
  * The `rebuild-env` task now uses the correct `--from-lockfile` option and explicitly outputs to `environment.yml` to ensure the environment file is generated properly.