### PR TITLE
Add skill_metrics Closes #443

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1,4 +1,4 @@
-name: analysis3
+name: default
 channels:
 - conda-forge
 - accessnri
@@ -1482,6 +1482,7 @@ dependencies:
   - accessvis==1.1.4
   - railroad-diagrams==3.0.1
   - sqlmodel==0.0.39
+  - skillmetrics==1.2.5
   - cc-plugin-wcrp==2.3.2
   - cmip7-data-request-api==1.4
 

--- a/environments/analysis3/pixi.lock
+++ b/environments/analysis3/pixi.lock
@@ -1490,6 +1490,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bf/ab/259b09a1ed4653378103f5a0edd9ad3eb3a8af995b11d9d52528807ae6e9/accessvis-1.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/43/fcf01f1ab9f744c545384bacea51016a267162de0b9e7c6fcd4996c84231/railroad_diagrams-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/7d/b9813a582d4eb310be35e1fc7dfaae71207d7b62e9e53be314ebd251b53b/sqlmodel-0.0.39-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/87/2cbe033663e8849e801d64255262f82366ec4784bc7a31edb186dc4255ae/skillmetrics-1.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/3d/302307d2f902a3fc95f0970a7f9d3c4647f4eed4e522858de3bd525d8f8b/cc_plugin_wcrp-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/91/923cb8ea3ed18ed9bd2fdf170b2fc4d6ef9543e45ca7f15dfd3d5248d505/cmip7_data_request_api-1.4-py3-none-any.whl
   default:
@@ -2980,6 +2981,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bf/ab/259b09a1ed4653378103f5a0edd9ad3eb3a8af995b11d9d52528807ae6e9/accessvis-1.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/43/fcf01f1ab9f744c545384bacea51016a267162de0b9e7c6fcd4996c84231/railroad_diagrams-3.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/7d/b9813a582d4eb310be35e1fc7dfaae71207d7b62e9e53be314ebd251b53b/sqlmodel-0.0.39-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/87/2cbe033663e8849e801d64255262f82366ec4784bc7a31edb186dc4255ae/skillmetrics-1.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/3d/302307d2f902a3fc95f0970a7f9d3c4647f4eed4e522858de3bd525d8f8b/cc_plugin_wcrp-2.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/91/923cb8ea3ed18ed9bd2fdf170b2fc4d6ef9543e45ca7f15dfd3d5248d505/cmip7_data_request_api-1.4-py3-none-any.whl
 packages:
@@ -27309,6 +27311,15 @@ packages:
   - pydantic>=2.11.0
   - typing-extensions>=4.5.0
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f4/87/2cbe033663e8849e801d64255262f82366ec4784bc7a31edb186dc4255ae/skillmetrics-1.2.5-py3-none-any.whl
+  name: skillmetrics
+  version: 1.2.5
+  sha256: ea7a32b12ed24698dc81e323cc22f16eb4d5b9f82e0afa7a291e7a7fef284ab5
+  requires_dist:
+  - matplotlib
+  - numpy
+  - pandas
+  - xlsxwriter
 - pypi: https://files.pythonhosted.org/packages/f6/3d/302307d2f902a3fc95f0970a7f9d3c4647f4eed4e522858de3bd525d8f8b/cc_plugin_wcrp-2.3.2-py3-none-any.whl
   name: cc-plugin-wcrp
   version: 2.3.2

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -355,3 +355,4 @@ nci-ipynb = ">=2023.11.0.3, <2024"
 cc-plugin-wcrp = ">=2.2.1, <3"
 esgvoc = ">=4.0.1, <5"
 frisky = ">=0.1.0, <0.2"           # Experimental - https://getfrisky.dev/. If it causes any issues we can remove it
+SkillMetrics = "*"


### PR DESCRIPTION
Adding the `skillmetrics` package to the dependencies.

Dependency updates:

* Added `skillmetrics==1.2.5` to the `dependencies` section in `environment.yml` to enable skill metrics calculations.
* Added `SkillMetrics` to the `pixi.toml` dependencies, ensuring it is installed in the environment.

Environment configuration:

* Renamed the environment from `analysis3` to `default` in `environment.yml`