### PR TITLE
Narrow the export strip to _x86_64-microarch-level only

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -1,4 +1,4 @@
-name: default
+name: analysis3
 channels:
 - conda-forge
 - accessnri
@@ -22,6 +22,7 @@ dependencies:
 - intake-virtual-icechunk ==0.2.2 py_0
 - yamanifest ==0.3.13 py_0
 - pygamma_n ==1.0.0 py312h4cfd3ad_1
+- _openmp_mutex ==4.5 7_kmp_llvm
 - aiohttp ==3.14.1 py312h5d8c7f2_0
 - alsa-lib ==1.2.16.1 hb03c661_0
 - aom ==3.9.1 hac33072_0
@@ -702,6 +703,8 @@ dependencies:
 - zlib-ng ==2.2.5 hde8ca8f_1
 - zstandard ==0.25.0 py312h5253ce2_1
 - zstd ==1.5.7 hb78ec9c_6
+- _python_abi3_support ==1.0 hd8ed1ab_2
+- _r-mutex ==1.0.1 anacondar_1
 - absl-py ==2.5.0 pyhd8ed1ab_0
 - access ==1.1.10.post3 pyhd8ed1ab_0
 - accessible-pygments ==0.0.5 pyhd8ed1ab_1

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -20,7 +20,7 @@ analysis3 = ["default"]
 
 [tasks]
 ensure-locked = { cmd = "pixi lock --check", description = "Ensure the lockfile is up to date" }
-rebuild-env = { cmd = "pixi workspace export conda-environment --platform linux-64 --name analysis3 --from-lock-file | grep -v '^- _' > environment.yml", description = "Rebuild environment.yml from lock file, dropping internal _-prefixed packages the solver re-adds transitively", depends-on = [
+rebuild-env = { cmd = "pixi workspace export conda-environment --platform linux-64 --name analysis3 --from-lock-file | grep -v '^- _x86_64-microarch-level ' > environment.yml", description = "Rebuild environment.yml from lock file, dropping _x86_64-microarch-level (its repodata depends on a build-string regex micromamba cannot parse; the solver re-adds it transitively)", depends-on = [
   "ensure-locked",
 ] }
 check-broken-packages = { cmd = "python3 check_broken_packages.py", description = "Check that broken-labelled packages in pixi.lock match pixi.toml declarations" }


### PR DESCRIPTION
Warning: Had Claude write this up for me

Narrows the `rebuild-env` workaround from "strip every `_`-prefixed package" to "strip `_x86_64-microarch-level`", and regenerates `environment.yml`.

The broad strip in #444 fixed a real crash, but it was wider than the actual defect and quietly cost us a pin that matters. Writeup below, mostly so we have the upstream story straight — I want to file this against conda-forge and the details decide where it lands.

## The failure

```
critical libmamba Error parsing version "1.*^". Version contains invalid characters in 1.*^.
```

## Root cause

Not `pixi workspace export` — that exported the lockfile faithfully. The problem is one package's repodata (`pixi.lock:15346`):

```
_x86_64-microarch-level-1-4_level1.conda
  depends:
  - __archspec 1.* ^(core2|k10|nocona|x86_64|...|zen5)$
```

That is a **regex build string**. libmamba's MatchSpec parser treats `|` and `(` as *version*-spec grammar (alternation / grouping), so it splits the string before it has separated version from build, and ends up with version `1.*` + `^` = the bogus `1.*^`.

Exactly **7 packages in all of conda-forge noarch** have this metadata shape — the `_x86_64-` and `_ppc64le-microarch-level` level packages. Our lock pinned one of them.

## Three parsers, three different answers

This is the part worth understanding before filing anything. Same dependency string:

| Parser | Result |
|---|---|
| **rattler** (pixi) | Parses correctly — resolved and locked `4_level1` |
| **libmamba** | Hard error: `Error parsing version "1.*^"` |
| **conda** 26.5.3 | Silently parses to `build='^$'` — matches **nothing** |

So libmamba is not uniquely broken; conda is broken too, just silently. Isolating what actually trips it (conda's `MatchSpec`):

```
p 1.* ^x86_64$                    build=^x86_64$    ✅ works
p 1.* ^(x86_64)$                  build=^$          ❌ parens eaten
p 1.* ^(a|b)$                     build=^$          ❌ parens eaten
p[version="1.*",build="^(a|b)$"]  build=^(a|b)$     ✅ works
```

Regex build strings **are** a supported conda feature — but only in the bracket syntax. In the three-part shorthand `name version build`, parentheses break the grammar. And repodata `depends` entries are *always* shorthand. So `_x86_64-microarch-level` is encoding something the shorthand grammar cannot represent.

Further findings from narrowing it:

- The trigger is the **alternation pipe**, not `^`/`$`. `pkg 1.* ^(a)$` solves fine under micromamba; `pkg 1.* ^(a|b)$` dies.
- Not `__archspec`-specific — `__unix 1.* ^(a|b)$` reproduces identically. It's the parser, not virtual-package handling.
- micromamba 2.0.8 / 2.3.0 / 2.8.1 all hard-error. 1.5.12 is arguably worse: it *silently* mis-parses to `__unix 1.*^$`, dropping the alternation.
- Only hit when parsing repodata `depends` during a solve. The same spec passed on the CLI or in an env file does not trigger it.

**Where the blame sits, roughly in order:** the conda-forge metadata is the primary defect. rattler is the permissive outlier, which is how an unbuildable package got into our lock in the first place — worth raising with pixi even though the export command is innocent. libmamba crashes rather than degrading, but conda's silent-mismatch is not obviously better.

*Caveat: I showed conda's `MatchSpec.match()` returns False for every build, which implies the package is uninstallable under conda too, but I did not check whether conda's solver special-cases virtual packages downstream. Treat "conda is also affected" as strongly indicated, not proven end-to-end.*

<details>
<summary>Self-contained reproducer (offline, one synthetic package)</summary>

Builds a one-package local channel whose only dependency is `__unix 1.* ^(a|b)$`:

```json
{"depends": ["__unix 1.* ^(a|b)$"]}
```

```
$ micromamba create --platform linux-64 -n repro --dry-run -c file://$PWD/ch regexdep
critical libmamba Error parsing version "1.*^". Version contains invalid characters in 1.*^.
```

Two-line version against the real channel:

```bash
micromamba create --platform linux-64 -n t --dry-run -c conda-forge \
  '_x86_64-microarch-level==1=4_level1'
```
</details>

## Why narrow the strip

`_openmp_mutex`, `_r-mutex` and `_python_abi3_support` are innocent — verified they solve fine when pinned. Only `_x86_64-microarch-level` is poisonous.

Stripping all of them meant losing:

```
_openmp_mutex ==4.5 7_kmp_llvm     # our lock: LLVM OpenMP runtime
```

An unpinned solve picks `_openmp_mutex 4.5 *_gnu` instead — confirmed. Both `llvm-openmp ==15.0.7` and `libgomp ==15.2.0` are still pinned in `environment.yml`, so the solver was free to go either way and the built env could silently diverge from `pixi.lock` on the OpenMP runtime. On an MPI/numerics stack that is not cosmetic.

## Verification

`micromamba create --dry-run --platform linux-64 -f environment.yml` on the regenerated file:

- ✅ Solves. **1462 packages.**
- ✅ `_openmp_mutex` resolves to `4.5 7_kmp_llvm` — matches the lock.
- ✅ `_x86_64-microarch-level` re-added transitively as `1 3_x86_64`.

Note that last one is a *different build* from the lock's `4_level1` — `3_x86_64` is the equivalent non-regex build. That lock/env divergence is inherent to the workaround and will persist until the upstream metadata is fixed. Benign (baseline microarch level either way), but it is there.

## Also in this diff

`name: default` → `name: analysis3`. The committed `environment.yml` predated the `--name analysis3` flag in the task, so it was stale against its own generator. Regenerating picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
