### PR TITLE
Update Moppy v1.6.8b

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -13,8 +13,8 @@ dependencies:
 - access-intake-esm ==2026.7.1 py_0
 - access-intake-utils ==0.1.7 py_0
 - access-med-tools ==0.1.23 pypy_0
-- access-moppy ==1.6.6b py_0
-- access-moppy-esmval ==1.6.6b 0
+- access-moppy ==1.6.8b py_0
+- access-moppy-esmval ==1.6.8b 0
 - access-nri-intake ==1.6.2 py_0
 - access-py-telemetry ==0.1.10 py_0
 - ecgtools-access ==2025.10.7 py_0

--- a/environments/analysis3/pixi.lock
+++ b/environments/analysis3/pixi.lock
@@ -1,11 +1,6 @@
 version: 7
 platforms:
 - name: linux-64
-  virtual-packages:
-  - __unix=0=0
-  - __linux=4.18
-  - __glibc=2.28
-  - __archspec=0=x86_64
 environments:
   analysis3:
     channels:
@@ -24,8 +19,8 @@ environments:
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-esm-2026.7.1-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-utils-0.1.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/access-med-tools-0.1.23-pypy_0.tar.bz2
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.6.6b-py_0.conda
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.6.6b-0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.6.8b-py_0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.6.8b-0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-py-telemetry-0.1.10-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/ecgtools-access-2025.10.7-py_0.tar.bz2
@@ -1516,8 +1511,8 @@ environments:
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-esm-2026.7.1-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-utils-0.1.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/access-med-tools-0.1.23-pypy_0.tar.bz2
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.6.6b-py_0.conda
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.6.6b-0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.6.8b-py_0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.6.8b-0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-py-telemetry-0.1.10-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/ecgtools-access-2025.10.7-py_0.tar.bz2
@@ -3052,9 +3047,9 @@ packages:
   license_family: APACHE
   size: 46216
   timestamp: 1761304298179
-- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.6.6b-py_0.conda
-  sha256: 564ae1473fd6062e6bed8ec14c1800ee49b83bd2bbecdaab91eb146e462f3609
-  md5: a46426a241db599e1c56d5864c6a71e8
+- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.6.8b-py_0.conda
+  sha256: 6f5f6b07ae7a3811b53de6b8cd8e1a3921a9b9e6307e439967e534d1c2d087f3
+  md5: 1e6629c2c1680e196cefcee22dff8d63
   depends:
   - cftime
   - dask
@@ -3070,18 +3065,18 @@ packages:
   - tqdm
   - xarray
   license: Apache-2.0
-  size: 11133998
-  timestamp: 1784188598657
-- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.6.6b-0.conda
+  size: 11151459
+  timestamp: 1784701704505
+- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.6.8b-0.conda
   noarch: python
-  sha256: f8cf9df2e0a4ecf69ada4d8879b05cc78a43c7713edfc6bd073f8a32d9f53256
-  md5: 3cd875b60c3dc151d87fd60da3ad42b8
+  sha256: c8d46ae1749c117fd44eed2676681e033f05b8a20d91e57fb1a45672df9ba99f
+  md5: bdbb56f8f7f7cbe240a921782ef7b37e
   depends:
-  - access-moppy 1.6.6b py_0
+  - access-moppy 1.6.8b py_0
   - esmvalcore >=2.14
   license: Apache-2.0
-  size: 9186
-  timestamp: 1784188608926
+  size: 9210
+  timestamp: 1784701714286
 - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
   sha256: 25d58c9af852d63c7bbba59062dad14e4ac2b4ecb11062843949a74634df9dfc
   md5: 446719c0e7d24f9471a8c717385fc596

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -53,7 +53,7 @@ intake-virtual-icechunk = { version = "==0.2.2", channel = "accessnri" }
 intake-dataframe-catalog = { version = "==0.5.1", channel = "conda-forge" }
 yamanifest = { version = ">=0.3.12", channel = "accessnri" }
 access-med-tools = { version = "==0.1.23", channel = "accessnri" }
-access-moppy-esmval = { version = "==1.6.6b", channel = "accessnri" }
+access-moppy-esmval = { version = "==1.6.8b", channel = "accessnri" }
 shumlib = { channel = "accessnri" }
 aiohttp = "*"
 aiohttp-cors = "*"


### PR DESCRIPTION
This pull request updates the versions of the `access-moppy` and `access-moppy-esmval` dependencies to ensure the environment uses the latest features and bug fixes. The changes are limited to dependency version bumps in both the `environment.yml` and `pixi.toml` files.

Dependency updates:

* Upgraded `access-moppy` from version `1.6.6b` to `1.6.8b` in `environments/analysis3/environment.yml` to include recent improvements and bug fixes.
* Upgraded `access-moppy-esmval` from version `1.6.6b` to `1.6.8b` in both `environments/analysis3/environment.yml` and `environments/analysis3/pixi.toml` for consistency across environment specifications. [[1]](diffhunk://#diff-77ec119817bc84dbca5a7c1d48f22f463d488222946291bf95ddc1ccf86a9d6dL16-R17) [[2]](diffhunk://#diff-492358c31a1423b8971571d4218c0d374673fcfc0c64b33fd129fd07bf5ad577L56-R56)