### PR TITLE
Update Moppy v1.7.4b

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -13,8 +13,8 @@ dependencies:
 - access-intake-esm ==2026.7.1 py_0
 - access-intake-utils ==0.1.7 py_0
 - access-med-tools ==0.1.23 pypy_0
-- access-moppy ==1.7.3b py_0
-- access-moppy-esmval ==1.7.3b 0
+- access-moppy ==1.7.4b py_0
+- access-moppy-esmval ==1.7.4b 0
 - access-nri-intake ==1.6.2 py_0
 - access-py-telemetry ==0.1.10 py_0
 - ecgtools-access ==2025.10.7 py_0

--- a/environments/analysis3/pixi.lock
+++ b/environments/analysis3/pixi.lock
@@ -24,8 +24,8 @@ environments:
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-esm-2026.7.1-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-utils-0.1.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/access-med-tools-0.1.23-pypy_0.tar.bz2
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.3b-py_0.conda
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.3b-0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.4b-py_0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.4b-0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-py-telemetry-0.1.10-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/ecgtools-access-2025.10.7-py_0.tar.bz2
@@ -1517,8 +1517,8 @@ environments:
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-esm-2026.7.1-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-utils-0.1.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/access-med-tools-0.1.23-pypy_0.tar.bz2
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.3b-py_0.conda
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.3b-0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.4b-py_0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.4b-0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-py-telemetry-0.1.10-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/ecgtools-access-2025.10.7-py_0.tar.bz2
@@ -3054,9 +3054,9 @@ packages:
   license_family: APACHE
   size: 46216
   timestamp: 1761304298179
-- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.3b-py_0.conda
-  sha256: 3daf2ca529e0581240cbdfb07de0bfb1c046b6b69ce430c68ac74bd1c0b8bcac
-  md5: 8d0b5bd46b51cc1b2f9958f3e758dfa2
+- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.4b-py_0.conda
+  sha256: a0d973284d706a09822bde95a4bf257e822fa5a834401faec908d3be179a462d
+  md5: 10eba046b7d84e54ffb190885825abdb
   depends:
   - cftime
   - dask
@@ -3072,18 +3072,18 @@ packages:
   - tqdm
   - xarray
   license: Apache-2.0
-  size: 11158784
-  timestamp: 1785301545343
-- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.3b-0.conda
+  size: 11152540
+  timestamp: 1785718745058
+- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.4b-0.conda
   noarch: python
-  sha256: 461c5a6fa5fbb0c712c163bd0fff03261fc56822aefb08d7c121f2a27ef4700f
-  md5: 6737345996d4772275e93664454d3653
+  sha256: d0167ca7eb22bee82a12aac28a01fc015a9092e4329adac7434b9e2a3844c9fc
+  md5: f75216333b40a1e05ebe6a19051b1e2d
   depends:
-  - access-moppy 1.7.3b py_0
+  - access-moppy 1.7.4b py_0
   - esmvalcore >=2.14
   license: Apache-2.0
-  size: 9168
-  timestamp: 1785301555213
+  size: 9197
+  timestamp: 1785718756078
 - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
   sha256: 25d58c9af852d63c7bbba59062dad14e4ac2b4ecb11062843949a74634df9dfc
   md5: 446719c0e7d24f9471a8c717385fc596
@@ -3799,7 +3799,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   run_exports: {}
   size: 239892
   timestamp: 1781450817988
@@ -4613,7 +4613,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/coverage?source=compressed-mapping
+  - pkg:pypi/coverage?source=hash-mapping
   run_exports: {}
   size: 394452
   timestamp: 1783019257881
@@ -13457,7 +13457,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=compressed-mapping
+  - pkg:pypi/ruff?source=hash-mapping
   run_exports: {}
   size: 9342178
   timestamp: 1782428525856
@@ -14202,7 +14202,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 864705
   timestamp: 1781006801632
@@ -15470,7 +15470,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/aiohappyeyeballs?source=compressed-mapping
+  - pkg:pypi/aiohappyeyeballs?source=hash-mapping
   run_exports: {}
   size: 24690
   timestamp: 1782986823268
@@ -15540,7 +15540,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/alembic?source=compressed-mapping
+  - pkg:pypi/alembic?source=hash-mapping
   run_exports: {}
   size: 185355
   timestamp: 1782460469542
@@ -16327,7 +16327,7 @@ packages:
   - python >=3.10
   license: ISC
   purls:
-  - pkg:pypi/certifi?source=compressed-mapping
+  - pkg:pypi/certifi?source=hash-mapping
   run_exports: {}
   size: 133877
   timestamp: 1781719949728
@@ -17366,7 +17366,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/decorator?source=compressed-mapping
+  - pkg:pypi/decorator?source=hash-mapping
   run_exports: {}
   size: 16102
   timestamp: 1779115228886
@@ -18341,7 +18341,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/fsspec?source=compressed-mapping
+  - pkg:pypi/fsspec?source=hash-mapping
   run_exports: {}
   size: 149709
   timestamp: 1781615868173
@@ -19131,7 +19131,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/idna?source=compressed-mapping
+  - pkg:pypi/idna?source=hash-mapping
   run_exports: {}
   size: 163869
   timestamp: 1781620148226
@@ -19460,7 +19460,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipython?source=compressed-mapping
+  - pkg:pypi/ipython?source=hash-mapping
   run_exports: {}
   size: 658801
   timestamp: 1782482716877
@@ -19677,7 +19677,7 @@ packages:
   - python
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/jedi?source=compressed-mapping
+  - pkg:pypi/jedi?source=hash-mapping
   run_exports: {}
   size: 2715215
   timestamp: 1782251948616
@@ -21030,7 +21030,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/narwhals?source=compressed-mapping
+  - pkg:pypi/narwhals?source=hash-mapping
   run_exports: {}
   size: 288381
   timestamp: 1782924928916
@@ -22016,7 +22016,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/platformdirs?source=compressed-mapping
+  - pkg:pypi/platformdirs?source=hash-mapping
   run_exports: {}
   size: 26308
   timestamp: 1779972894916
@@ -24523,7 +24523,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/requests?source=compressed-mapping
+  - pkg:pypi/requests?source=hash-mapping
   run_exports: {}
   size: 68709
   timestamp: 1778851103479
@@ -25155,7 +25155,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/soupsieve?source=compressed-mapping
+  - pkg:pypi/soupsieve?source=hash-mapping
   run_exports: {}
   size: 38802
   timestamp: 1779635534390
@@ -25817,7 +25817,7 @@ packages:
   - ipywidgets >=6.0
   license: MPL-2.0 and MIT
   purls:
-  - pkg:pypi/tqdm?source=compressed-mapping
+  - pkg:pypi/tqdm?source=hash-mapping
   run_exports: {}
   size: 94965
   timestamp: 1781741268338
@@ -26437,7 +26437,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/wcwidth?source=compressed-mapping
+  - pkg:pypi/wcwidth?source=hash-mapping
   run_exports: {}
   size: 132415
   timestamp: 1782771807703
@@ -27130,7 +27130,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/zipp?source=compressed-mapping
+  - pkg:pypi/zipp?source=hash-mapping
   run_exports: {}
   size: 24190
   timestamp: 1779159948016

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -62,7 +62,7 @@ intake-virtual-icechunk = { version = "==0.2.2", channel = "accessnri" }
 intake-dataframe-catalog = { version = "==0.5.1", channel = "conda-forge" }
 yamanifest = { version = ">=0.3.12", channel = "accessnri" }
 access-med-tools = { version = "==0.1.23", channel = "accessnri" }
-access-moppy-esmval = { version = "==1.7.3b", channel = "accessnri" }
+access-moppy-esmval = { version = "==1.7.4b", channel = "accessnri" }
 shumlib = { channel = "accessnri" }
 aiohttp = "*"
 aiohttp-cors = "*"


### PR DESCRIPTION
This pull request updates the `access-moppy` and `access-moppy-esmval` dependencies to version `1.7.4b` in both the `environment.yml` and `pixi.toml` files. These updates ensure the environment uses the latest bug fixes and features from these packages.

Dependency updates:
* Updated `access-moppy` to version `1.7.4b` in `environments/analysis3/environment.yml`
* Updated `access-moppy-esmval` to version `1.7.4b` in both `environments/analysis3/environment.yml` and `environments/analysis3/pixi.toml` [[1]](diffhunk://#diff-77ec119817bc84dbca5a7c1d48f22f463d488222946291bf95ddc1ccf86a9d6dL16-R17) [[2]](diffhunk://#diff-492358c31a1423b8971571d4218c0d374673fcfc0c64b33fd129fd07bf5ad577L65-R65)