### PR TITLE
Update benchcab to v4.3.2

### DIFF
--- a/environments/benchcab/config.sh
+++ b/environments/benchcab/config.sh
@@ -1,6 +1,6 @@
 # Note: BENCHCAB_VERSION should match the version of benchcab in
 # environments/benchcab/environment.yml:
-BENCHCAB_VERSION=4.3.1
+BENCHCAB_VERSION=4.3.2
 export ENVIRONMENT="benchcab"
 export STABLE_VERSION="${BENCHCAB_VERSION}"
 export FULLENV="${ENVIRONMENT}-${BENCHCAB_VERSION}"

--- a/environments/benchcab/environment.yml
+++ b/environments/benchcab/environment.yml
@@ -6,5 +6,5 @@ channels:
 dependencies:
 # Note: the pinned benchcab version should match the BENCHCAB_VERSION
 # environment variable in environments/benchcab/config.sh:
-- accessnri::benchcab==4.3.1
+- accessnri::benchcab==4.3.2
 - accessnri::payu>=1.1.7


### PR DESCRIPTION
This release brings across some fixes from the `meorg_client` dependency and includes some additional enhancements.

Please see the [v4.3.2 release notes](https://github.com/CABLE-LSM/benchcab/releases/tag/v4.3.2) for more information.