### PR TITLE
Update/moppy v1.7.8b

### DIFF
--- a/environments/analysis3/environment.yml
+++ b/environments/analysis3/environment.yml
@@ -13,8 +13,8 @@ dependencies:
 - access-intake-esm ==2026.7.1 py_0
 - access-intake-utils ==0.1.7 py_0
 - access-med-tools ==0.1.23 pypy_0
-- access-moppy ==1.7.7b py_0
-- access-moppy-esmval ==1.7.7b 0
+- access-moppy ==1.7.8b py_0
+- access-moppy-esmval ==1.7.8b 0
 - access-nri-intake ==1.6.2 py_0
 - access-py-telemetry ==0.1.10 py_0
 - ecgtools-access ==2025.10.7 py_0

--- a/environments/analysis3/pixi.lock
+++ b/environments/analysis3/pixi.lock
@@ -24,8 +24,8 @@ environments:
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-esm-2026.7.1-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-utils-0.1.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/access-med-tools-0.1.23-pypy_0.tar.bz2
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.7b-py_0.conda
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.7b-0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.8b-py_0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.8b-0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-py-telemetry-0.1.10-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/ecgtools-access-2025.10.7-py_0.tar.bz2
@@ -1517,8 +1517,8 @@ environments:
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-esm-2026.7.1-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-intake-utils-0.1.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/access-med-tools-0.1.23-pypy_0.tar.bz2
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.7b-py_0.conda
-      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.7b-0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.8b-py_0.conda
+      - conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.8b-0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
       - conda: https://conda.anaconda.org/accessnri/noarch/access-py-telemetry-0.1.10-py_0.tar.bz2
       - conda: https://conda.anaconda.org/accessnri/noarch/ecgtools-access-2025.10.7-py_0.tar.bz2
@@ -3054,9 +3054,9 @@ packages:
   license_family: APACHE
   size: 46216
   timestamp: 1761304298179
-- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.7b-py_0.conda
-  sha256: 737b8a9bec48966557a3daad1a6f38560f3f53d9718285e94465af67c7231f85
-  md5: 9dcc78812e92faf233c877c852f56643
+- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-1.7.8b-py_0.conda
+  sha256: 6df419236c709b6fb6fc1d6ce48c5ddf1e31dc1714ca64bde0ae9262e503de40
+  md5: 8176a17b36dd5a084fdea1ed5b1a11d6
   depends:
   - cftime
   - dask
@@ -3072,18 +3072,18 @@ packages:
   - tqdm
   - xarray
   license: Apache-2.0
-  size: 11170589
-  timestamp: 1785919365733
-- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.7b-0.conda
+  size: 11172614
+  timestamp: 1785973866715
+- conda: https://conda.anaconda.org/accessnri/noarch/access-moppy-esmval-1.7.8b-0.conda
   noarch: python
-  sha256: cfd08bfb73cbdcec84db41a39d6d657b06de407987c1c5510f4dc32792a7ed62
-  md5: 41ef267e36f59000b7f19dc1d53311cf
+  sha256: 1a2686d6dc638864ef47f044416a36f6ca9b8b10f204c22ec899c777a9d738de
+  md5: 03ced571f1f83842831d81f02ea5cd24
   depends:
-  - access-moppy 1.7.7b py_0
+  - access-moppy 1.7.8b py_0
   - esmvalcore >=2.14
   license: Apache-2.0
-  size: 9140
-  timestamp: 1785919377110
+  size: 9171
+  timestamp: 1785973876842
 - conda: https://conda.anaconda.org/accessnri/noarch/access-nri-intake-1.6.2-py_0.conda
   sha256: 25d58c9af852d63c7bbba59062dad14e4ac2b4ecb11062843949a74634df9dfc
   md5: 446719c0e7d24f9471a8c717385fc596

--- a/environments/analysis3/pixi.toml
+++ b/environments/analysis3/pixi.toml
@@ -62,7 +62,7 @@ intake-virtual-icechunk = { version = "==0.2.2", channel = "accessnri" }
 intake-dataframe-catalog = { version = "==0.5.1", channel = "conda-forge" }
 yamanifest = { version = ">=0.3.12", channel = "accessnri" }
 access-med-tools = { version = "==0.1.23", channel = "accessnri" }
-access-moppy-esmval = { version = "==1.7.7b", channel = "accessnri" }
+access-moppy-esmval = { version = "==1.7.8b", channel = "accessnri" }
 shumlib = { channel = "accessnri" }
 aiohttp = "*"
 aiohttp-cors = "*"


### PR DESCRIPTION
This pull request updates the `access-moppy` and `access-moppy-esmval` dependencies to version `1.7.8b` in both the `environment.yml` and `pixi.toml` files. This ensures consistency across environments and brings in the latest features or fixes from these packages.

**Dependency updates:**

* Updated `access-moppy` to version `1.7.8b` in `environments/analysis3/environment.yml`
* Updated `access-moppy-esmval` to version `1.7.8b` in both `environments/analysis3/environment.yml` and `environments/analysis3/pixi.toml` [[1]](diffhunk://#diff-77ec119817bc84dbca5a7c1d48f22f463d488222946291bf95ddc1ccf86a9d6dL16-R17) [[2]](diffhunk://#diff-492358c31a1423b8971571d4218c0d374673fcfc0c64b33fd129fd07bf5ad577L65-R65)